### PR TITLE
Introduce fallback value for config to prevent crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 !*.config
 !*.settings
 !*.ps1
+!*.manifest
 
 # c++ / c#
 !*.h

--- a/SharkCage/CageConfigurator/CageConfigurator.csproj
+++ b/SharkCage/CageConfigurator/CageConfigurator.csproj
@@ -47,6 +47,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup />
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AForge, Version=2.2.5.0, Culture=neutral, PublicKeyToken=c1db6ff4eaa06aeb, processorArchitecture=MSIL">
       <HintPath>..\packages\AForge.2.2.5\lib\AForge.dll</HintPath>

--- a/SharkCage/CageConfigurator/CageConfiguratorForm.cs
+++ b/SharkCage/CageConfigurator/CageConfiguratorForm.cs
@@ -408,7 +408,9 @@ namespace CageConfigurator
 
                     writer.WriteStartObject();
                     writer.WritePropertyName("application_name");
-                    writer.WriteValue(FileVersionInfo.GetVersionInfo(applicationPath.Text)?.FileDescription);
+                    var app_name = FileVersionInfo.GetVersionInfo(applicationPath.Text)?.FileDescription;
+                    app_name = app_name ?? Path.GetFileName(applicationPath.Text);
+                    writer.WriteValue(app_name);
                     writer.WritePropertyName(APPLICATION_PATH_PROPERTY);
                     writer.WriteValue(applicationPath.Text);
                     writer.WritePropertyName("has_signature");

--- a/SharkCage/CageConfigurator/app.manifest
+++ b/SharkCage/CageConfigurator/app.manifest
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the 
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on and is
+           is designed to work with. Uncomment the appropriate elements and Windows will 
+           automatically selected the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+
+      <!-- Windows 10 -->
+      <!--<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />-->
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/SharkCage/SharedFunctionality/SharedFunctions.cpp
+++ b/SharkCage/SharedFunctionality/SharedFunctions.cpp
@@ -78,7 +78,14 @@ namespace SharedFunctions
 				config_stream >> json_config;
 
 				auto path = json_config[APPLICATION_PATH_PROPERTY].get<std::string>();
-				auto application_name = json_config[APPLICATION_NAME_PROPERTY].get<std::string>();
+
+				auto application_name_json = json_config[APPLICATION_NAME_PROPERTY];
+				std::string application_name = "Name not available";
+				if (!application_name_json.is_null())
+				{
+					application_name = application_name_json.get<std::string>();
+				}
+
 				auto token = json_config[APPLICATION_TOKEN_PROPERTY].get<std::string>();
 				auto hash = json_config[APPLICATION_HASH_PROPERTY].get<std::string>();
 				auto additional_application = json_config[ADDITIONAL_APPLICATION_NAME_PROPERTY].get<std::string>();
@@ -104,6 +111,11 @@ namespace SharedFunctions
 				}
 
 				return true;
+			}
+			catch (nlohmann::json::exception& e)
+			{
+				std::cout << "Could not parse json: " << e.what() << std::endl;
+				return false;
 			}
 			catch (std::exception e)
 			{


### PR DESCRIPTION
fixes #67 

The manifest commit is not directly associated with the issue - it is needed so the configurator is started with admin privileges (in order to save the config with access for the admin group only). It should have been included previously.