### PR TITLE
dll export for tokenLibrary

### DIFF
--- a/SharkCage/SharedFunctionality/SharedFunctionality.vcxproj
+++ b/SharkCage/SharedFunctionality/SharedFunctionality.vcxproj
@@ -195,6 +195,7 @@ xcopy /y "$(OutDir)$(TargetName).dll" "$(SolutionDir)CageChooser\bin\$(Configura
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="tokenLib\groupManipulation.h" />
+    <ClInclude Include="tokenLib\stdafx.h" />
     <ClInclude Include="tokenLib\tokenManipulation.h" />
   </ItemGroup>
   <ItemGroup>

--- a/SharkCage/SharedFunctionality/SharedFunctionality.vcxproj.filters
+++ b/SharkCage/SharedFunctionality/SharedFunctionality.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="tokenLib\tokenManipulation.h">
       <Filter>Header Files\TokenLib</Filter>
     </ClInclude>
+    <ClInclude Include="tokenLib\stdafx.h">
+      <Filter>Header Files\TokenLib</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">

--- a/SharkCage/SharedFunctionality/tokenLib/groupManipulation.h
+++ b/SharkCage/SharedFunctionality/tokenLib/groupManipulation.h
@@ -9,20 +9,20 @@ namespace tokenLib {
 	* @param sid reference to the new group sid, set to NULL if function fails (OUT)
 	* @return true if success
 	**/
-	bool createLocalGroup(LPWSTR groupName, PSID &sid);
+	DLLEXPORT bool createLocalGroup(LPWSTR groupName, PSID &sid);
 
 	/**
 	* Deletes a local group named groupName
 	* @param groupName name of the group to be deleted
 	* @return true if success
 	**/
-	bool deleteLocalGroup(LPWSTR groupName);
+	DLLEXPORT bool deleteLocalGroup(LPWSTR groupName);
 
 	/**
 	* Deallocates an SID returned by createLocalGroup() function and sets the pointer to NULL;
 	* @param sid pointer to sid alllocated by createLocalGroup()
 	* @return true if success
 	**/
-	bool destroySid(PSID &sid);
+	DLLEXPORT bool destroySid(PSID &sid);
 
 }

--- a/SharkCage/SharedFunctionality/tokenLib/stdafx.h
+++ b/SharkCage/SharedFunctionality/tokenLib/stdafx.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "../stdafx.h"

--- a/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
@@ -67,7 +67,7 @@ public:
 
 namespace tokenLib {
 
-	bool createLocalGroup(LPWSTR groupName, PSID &sid) {
+	DLLEXPORT bool createLocalGroup(LPWSTR groupName, PSID &sid) {
 		LOCALGROUP_INFO_0 localGroupInfo;
 		localGroupInfo.lgrpi0_name = groupName;
 
@@ -83,19 +83,19 @@ namespace tokenLib {
 		return getGroupSid(groupName,sid);
 	}
 
-	bool destroySid(PSID &sid) {
+	DLLEXPORT bool destroySid(PSID &sid) {
 		delete[](BYTE*) sid;
 		sid = NULL;
 		return true;
 	}
 
-	bool deleteLocalGroup(LPWSTR groupName) {
+	DLLEXPORT bool deleteLocalGroup(LPWSTR groupName) {
 		if (NetLocalGroupDel(NULL, groupName) != NERR_Success)
 			return false;
 		return true;
 	}
 
-	bool constructUserTokenWithGroup(LPWSTR groupName, HANDLE &token) {
+	DLLEXPORT bool constructUserTokenWithGroup(LPWSTR groupName, HANDLE &token) {
 		PSID groupSid = 0;
 		if (!getGroupSid(groupName,groupSid)){
 			token = 0;
@@ -110,7 +110,7 @@ namespace tokenLib {
 		destroySid(groupSid);
 		return true;
 	}
-	bool constructUserTokenWithGroup(PSID sid, HANDLE &token) {
+	DLLEXPORT bool constructUserTokenWithGroup(PSID sid, HANDLE &token) {
 
 		HANDLE userToken = 0;
 

--- a/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
@@ -19,7 +19,7 @@ namespace tokenLib {
 	* @param token reference to handle to requested token (OUT)
 	* @return true if success
 	**/
-	bool constructUserTokenWithGroup(PSID sid, HANDLE &token);
+	DLLEXPORT bool constructUserTokenWithGroup(PSID sid, HANDLE &token);
 
 	/**
 	* Function gets a name of a group and creates a token with a group entry added in the token. The group must exist, otherwise the function will fail
@@ -33,7 +33,7 @@ namespace tokenLib {
 	* @param token reference to handle to requested token (OUT)
 	* @return true if success
 	**/
-	bool constructUserTokenWithGroup(LPWSTR groupName, HANDLE &token);
+	DLLEXPORT bool constructUserTokenWithGroup(LPWSTR groupName, HANDLE &token);
 
 	//alternative token sourcing: 
 	//another approach would be to use wtsQueryUserToken and determine session of current user


### PR DESCRIPTION
Fix to a linker issue introduced by #60 (Moved tokenLib to SharedFuctionality, but not exported to DLL)