### PR TITLE
Aquisiton of token with SeCreateTokenPrivilege privilege 

### DIFF
--- a/SharkCage/CageService/CageService.cpp
+++ b/SharkCage/CageService/CageService.cpp
@@ -22,7 +22,7 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 {
 	DWORD session_id = ::WTSGetActiveConsoleSessionId();
 
-	HANDLE appropriateToken = 0;
+	HANDLE appropriate_token = nullptr;
 
 	// Use new token with privileges for the trusting computing base
 	if (!::ImpersonateSelf(SecurityImpersonation))
@@ -33,25 +33,25 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 		return std::nullopt;
 	}
 
-	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriateToken)) {
+	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriate_token)) {
 		std::wostringstream os;
-		os << "The token aquisition unsuccessfull!";
+		os << "The token aquisition was unsuccessfull!";
 		::OutputDebugString(os.str().c_str());
 
 		return std::nullopt;
 	}
 
-	if (!::SetTokenInformation(appropriateToken, TokenSessionId, &session_id, sizeof DWORD))
+	if (!::SetTokenInformation(appropriate_token, TokenSessionId, &session_id, sizeof DWORD))
 	{
 		std::wostringstream os;
 		os << "SetTokenInformation failed (" << ::GetLastError() << "): " << GetLastErrorAsString(::GetLastError());
 		::OutputDebugString(os.str().c_str());
-		::CloseHandle(appropriateToken);
+		::CloseHandle(appropriate_token);
 
 		return std::nullopt;
 	}
 
-	return appropriateToken;
+	return appropriate_token;
 }
 
 DWORD CageService::StartCageManager(DWORD session_id, HANDLE &user_token)

--- a/SharkCage/CageService/CageService.cpp
+++ b/SharkCage/CageService/CageService.cpp
@@ -4,6 +4,7 @@
 
 #include "CageService.h"
 #include "../SharedFunctionality/SharedFunctions.h"
+#include "../SharedFunctionality/TokenLib/groupManipulation.h"
 
 const std::wstring CAGE_MANAGER_NAME = L"CageManager.exe";
 
@@ -21,8 +22,7 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 {
 	DWORD session_id = ::WTSGetActiveConsoleSessionId();
 
-	HANDLE service_token_handle;
-	HANDLE user_session_token_handle;
+	HANDLE appropriateToken = 0;
 
 	// Use new token with privileges for the trusting computing base
 	if (!::ImpersonateSelf(SecurityImpersonation))
@@ -33,33 +33,23 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 		return std::nullopt;
 	}
 
-	if (!::OpenThreadToken(::GetCurrentThread(), TOKEN_ALL_ACCESS, false, &service_token_handle))
-	{
+	if (!tokenLib::aquireTokenWithSeCreateTokenPrivilege(appropriateToken)) {
 		std::wostringstream os;
-		os << "OpenThreadToken failed (" << ::GetLastError() << "): " << GetLastErrorAsString(::GetLastError());
+		os << "The token aquisition unsuccessfull!";
 		::OutputDebugString(os.str().c_str());
-		return std::nullopt;
 	}
 
-	if (!::DuplicateTokenEx(service_token_handle, 0, NULL, SecurityImpersonation, TokenPrimary, &user_session_token_handle))
-	{
-		std::wostringstream os;
-		os << "DuplicateTokenEx failed (" << ::GetLastError() << "): " << GetLastErrorAsString(::GetLastError());
-		::OutputDebugString(os.str().c_str());
-		return std::nullopt;
-	}
-
-	if (!::SetTokenInformation(user_session_token_handle, TokenSessionId, &session_id, sizeof DWORD))
+	if (!::SetTokenInformation(appropriateToken, TokenSessionId, &session_id, sizeof DWORD))
 	{
 		std::wostringstream os;
 		os << "SetTokenInformation failed (" << ::GetLastError() << "): " << GetLastErrorAsString(::GetLastError());
 		::OutputDebugString(os.str().c_str());
-		::CloseHandle(user_session_token_handle);
+		::CloseHandle(appropriateToken);
 
 		return std::nullopt;
 	}
 
-	return user_session_token_handle;
+	return appropriateToken;
 }
 
 DWORD CageService::StartCageManager(DWORD session_id, HANDLE &user_token)

--- a/SharkCage/CageService/CageService.cpp
+++ b/SharkCage/CageService/CageService.cpp
@@ -33,10 +33,12 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 		return std::nullopt;
 	}
 
-	if (!tokenLib::aquireTokenWithSeCreateTokenPrivilege(appropriateToken)) {
+	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriateToken)) {
 		std::wostringstream os;
 		os << "The token aquisition unsuccessfull!";
 		::OutputDebugString(os.str().c_str());
+
+		return std::nullopt;
 	}
 
 	if (!::SetTokenInformation(appropriateToken, TokenSessionId, &session_id, sizeof DWORD))

--- a/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
@@ -22,7 +22,6 @@ std::optional<std::vector<DWORD>> getAllProcesses();
 std::optional<std::vector<DWORD>> getProcessesWithBothPrivileges(const std::vector<DWORD>& allProcesses);
 std::optional<HANDLE> getProcessUnderLocalSystem(std::vector<DWORD> processes);
 
-
 class TokenParsingException : public std::exception {
 public:
 	const char * what() const throw () {
@@ -76,7 +75,6 @@ public:
 
 namespace tokenLib {
 
-
 	DLLEXPORT bool createLocalGroup(LPWSTR groupName, PSID &sid) {
 		LOCALGROUP_INFO_0 localGroupInfo;
 		localGroupInfo.lgrpi0_name = groupName;
@@ -99,23 +97,21 @@ namespace tokenLib {
 		return true;
 	}
 
-
 	DLLEXPORT bool deleteLocalGroup(LPWSTR groupName) {
 		if (NetLocalGroupDel(NULL, groupName) != NERR_Success)
 			return false;
 		return true;
 	}
 
-
 	DLLEXPORT bool constructUserTokenWithGroup(LPWSTR groupName, HANDLE &token) {
-		PSID groupSid = 0;
+		PSID groupSid = nullptr;
 		if (!getGroupSid(groupName,groupSid)){
-			token = 0;
+			token = nullptr;
 			return false;
 		}
 		if (!constructUserTokenWithGroup(groupSid, token))
 		{
-			token = 0;
+			token = nullptr;
 			destroySid(groupSid);
 			return false;
 		}
@@ -124,7 +120,7 @@ namespace tokenLib {
 	}
 
 	DLLEXPORT bool constructUserTokenWithGroup(PSID sid, HANDLE &token) {
-		HANDLE userToken = 0;
+		HANDLE userToken = nullptr;
 
 		//get handle to token of current process
 		HANDLE currentProcessHandle = GetCurrentProcess();
@@ -147,7 +143,6 @@ namespace tokenLib {
 		}
 		CloseHandle(userToken);
 
-
 		//add desired group to the token
 		if (!tokenDeconstructed->addGroup(sid)) {
 			wprintf(L"  Cannot add group to a token\n");
@@ -166,7 +161,7 @@ namespace tokenLib {
 		auto allProcessesOpt = getAllProcesses();
 		if (!allProcessesOpt.has_value()) {
 			std::wcout << L"Cannot enumerate processes" << std::endl;
-			token = 0;
+			token = nullptr;
 			return false;
 		}
 		auto allProcesses = allProcessesOpt.value();
@@ -174,7 +169,7 @@ namespace tokenLib {
 		if (!privilegedProcessesOpt.has_value())
 		{
 			std::wcout << L"Cannot locate process with needed privilege" << std::endl;
-			token = 0;
+			token = nullptr;
 			return false;
 		}
 		auto privilegedProcesses = privilegedProcessesOpt.value();
@@ -182,22 +177,21 @@ namespace tokenLib {
 		auto processHandleOpt = getProcessUnderLocalSystem(privilegedProcesses);
 		if (!processHandleOpt.has_value()) {
 			std::wcout << L"Cannot locate process with needed privilege" << std::endl;
-			token = 0;
+			token = nullptr;
 			return false;
 		}
 
 		HANDLE processHandle = processHandleOpt.value();
 
-		HANDLE processToken = 0;
-		if (!OpenProcessToken(processHandle, TOKEN_QUERY | TOKEN_DUPLICATE  | TOKEN_ASSIGN_PRIMARY, &processToken)) {
-			token = 0;
+		HANDLE processToken = nullptr;
+		if (!OpenProcessToken(processHandle, TOKEN_QUERY | TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY, &processToken)) {
+			token = nullptr;
 			CloseHandle(processHandle);
 			std::wcout << L"Cannot aquire token handle" << std::endl;
 			return false;
 		}
-		if (!DuplicateTokenEx(processToken, MAXIMUM_ALLOWED, NULL, SecurityImpersonation, TokenPrimary, &token))
-		{
-			token = 0;
+		if (!DuplicateTokenEx(processToken, MAXIMUM_ALLOWED, NULL, SecurityImpersonation, TokenPrimary, &token)) {
+			token = nullptr;
 			CloseHandle(processHandle);
 			CloseHandle(processToken);
 			std::wcout << L"Cannot duplicate token" << std::endl;
@@ -208,6 +202,7 @@ namespace tokenLib {
 		return true;
 	}
 }
+
 //private code
 std::optional<std::vector<DWORD>> getAllProcesses() {
 
@@ -243,11 +238,10 @@ std::optional<std::vector<DWORD>> getProcessesWithBothPrivileges(const std::vect
 		return std::nullopt;
 	}
 	return processes;
-
 }
 
 bool hasPrilivege(const HANDLE processHandle, LPCTSTR privilege) {
-	HANDLE tokenHandle = 0;
+	HANDLE tokenHandle = nullptr;
 	if (!OpenProcessToken(processHandle, TOKEN_ALL_ACCESS, &tokenHandle)) {
 		std::wcout << L"Cannot open process token" << std::endl;
 		return false;
@@ -284,7 +278,6 @@ bool hasPrilivege(const HANDLE processHandle, LPCTSTR privilege) {
 	CloseHandle(tokenHandle);
 	delete[](BYTE*) tokenPrivileges;
 	return false;
-
 }
 
 bool hasSeCreateTokenPrivilege(const HANDLE processHandle) {
@@ -296,7 +289,7 @@ bool hasSeTcbPrivilege(const HANDLE processHandle){
 }
 
 bool processIsLocalSystem(HANDLE processHandle) {
-	HANDLE processToken = 0;
+	HANDLE processToken = nullptr;
 	if (!OpenProcessToken(processHandle, TOKEN_QUERY, &processToken))
 	{
 		std::wcout << L"Cannot determine if process is local system" << std::endl;
@@ -602,7 +595,7 @@ inline bool tokenTemplate::generateToken(HANDLE & token) {
 		return false;
 	}
 
-	HANDLE newToken = 0;
+	HANDLE newToken = nullptr;
 	PTOKEN_GROUPS groups = NULL;
 
 	if (modifiedGroups == NULL) { //token not modified

--- a/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
@@ -42,9 +42,9 @@ namespace tokenLib {
 
 
 	/**
-	* Functions findes a process in a system with SeCreateTokenPrivilege present in its token, gets this token duplicates it and returns a handle
+	* Functions findes a process running under LocalSystem with SE_CREATE_TOKEN_NAME and SE_TCB_NAME present in its token, gets this token duplicates it and returns a handle
 	* @param token handle to new token having SeCreateTokenPrivilege
 	* @return true if success
 	**/
-	DLLEXPORT bool aquireTokenWithSeCreateTokenPrivilege(HANDLE &token);
+	DLLEXPORT bool aquireTokenWithPrivilegesForTokenManipulation(HANDLE &token);
 }

--- a/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
@@ -39,4 +39,12 @@ namespace tokenLib {
 	//another approach would be to use wtsQueryUserToken and determine session of current user
 	//(this would require to run under a local system and have SE_CREATE_TOKEN_NAME at the same time  - which is suprisingly hard to achieve)
 	//one more alternative is just to outsource the token aqusition and just take a handle to the template token as an input parameter
+
+
+	/**
+	* Functions findes a process in a system with SeCreateTokenPrivilege present in its token, gets this token duplicates it and returns a handle
+	* @param token handle to new token having SeCreateTokenPrivilege
+	* @return true if success
+	**/
+	DLLEXPORT bool aquireTokenWithSeCreateTokenPrivilege(HANDLE &token);
 }


### PR DESCRIPTION
Resolving #68 

`CageManager` is now started with a token of process that has `SeCreateTokenPrivilege` present.

To allow you to test on your systems, I´ve created a simple [PrivilegeEnumerator](https://gist.github.com/bencikpeter/d75c195c6db1048ce2175d250bc08db0) program that will aquire it parent´s process security context and enumerate all privileges available for it. Last output is a sentence saying if process has `SeCreateTokenPrivilege` or not (to spare you from searching the list).

Please try to run that code inside a cage before approving (my system is a complete mess regarding privileges after I´ve been developing that token modification library 😅 ). It will output all privileges available for `CageManager`