### PR TITLE
Starting caged applications under correct priviliges

### DIFF
--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -23,8 +23,32 @@ int main()
 	CageManager cage_manager;
 
 	SecuritySetup security_setup;
-	//TODO randomize the group name
-	std::wstring group_name = L"Shark_cage_test_group";
+	//randomize the group name
+	UUID uuid;
+	if (::UuidCreate(&uuid) != RPC_S_OK)
+	{
+		std::cout << "Failed to create UUID" << std::endl;
+		return 1;
+	}
+
+	RPC_WSTR uuid_str;
+	if (::UuidToString(&uuid, &uuid_str) != RPC_S_OK)
+	{
+		std::cout << "Failed to convert UUID to rpc string" << std::endl;
+		return 1;
+	}
+
+	std::wstring uuid_stl(reinterpret_cast<wchar_t*>(uuid_str));
+	if (uuid_stl.empty())
+	{
+		::RpcStringFree(&uuid_str);
+		std::cout << "Failed to convert UUID rpc string to stl string" << std::endl;
+		return 1;
+	}
+
+	::RpcStringFree(&uuid_str);
+
+	std::wstring group_name = std::wstring(L"shark_cage_group_").append(uuid_stl);
 	auto security_attributes = security_setup.GetSecurityAttributes(group_name);
 
 	if (!security_attributes.has_value())

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -23,7 +23,9 @@ int main()
 	CageManager cage_manager;
 
 	SecuritySetup security_setup;
-	auto security_attributes = security_setup.GetSecurityAttributes();
+	//TODO randomize the group name
+	std::wstring group_name = L"Shark_cage_test_group";
+	auto security_attributes = security_setup.GetSecurityAttributes(group_name);
 
 	if (!security_attributes.has_value())
 	{

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -3,6 +3,7 @@
 #include "../SharedFunctionality/NetworkManager.h"
 #include "../SharedFunctionality/SharedFunctions.h"
 #include "../SharedFunctionality/CageData.h"
+#include "../SharedFunctionality/tokenLib/groupManipulation.h"
 
 #include "Aclapi.h"
 
@@ -64,6 +65,7 @@ int main()
 
 	if (parse_result != CageMessage::START_PROCESS)
 	{
+		tokenLib::deleteLocalGroup(static_cast<LPWSTR const>(const_cast<wchar_t*>((group_name.c_str()))));
 		std::cout << "Could not process incoming message" << std::endl;
 		return 1;
 	}
@@ -71,6 +73,7 @@ int main()
 	CageData cage_data = { message_data };
 	if (!SharedFunctions::ParseStartProcessMessage(cage_data))
 	{
+		tokenLib::deleteLocalGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))));
 		std::cout << "Could not process start process message" << std::endl;
 		return 1;
 	}
@@ -84,7 +87,7 @@ int main()
 	);
 
 	desktop_thread.join();
-
+	tokenLib::deleteLocalGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))));
 	return 0;
 }
 

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -119,6 +119,15 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 
 	::RpcStringFree(&uuid_str);
 	
+	HANDLE tokenHandle = 0;
+	//TODO: close this handle
+	if (!tokenLib::constructUserTokenWithGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))), tokenHandle)) {
+		std::cout << "Cannot create required token" << std::endl;
+		getchar();
+		return;
+		
+	}
+
 	const std::wstring DESKTOP_NAME = std::wstring(L"shark_cage_desktop_").append(uuid_stl);
 	const int work_area_width = 300;
 	CageDesktop cage_desktop(
@@ -143,8 +152,6 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 		LABELER_WINDOW_CLASS_NAME
 	);
 
-	//PETER´S ACCESS TOKEN THINGS
-
 	// We need in order to create the process.
 	STARTUPINFO info = {};
 	info.dwFlags = STARTF_USESHOWWINDOW;
@@ -158,7 +165,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	std::vector<wchar_t> path_buf(cage_data.app_path.begin(), cage_data.app_path.end());
 	path_buf.push_back(0);
 
-	if (::CreateProcess(path_buf.data(), nullptr, &security_attributes, nullptr, FALSE, 0, nullptr, nullptr, &info, &process_info) == 0)
+	if (::CreateProcessAsUser(tokenHandle, path_buf.data(), nullptr, &security_attributes, nullptr, false, 0, nullptr, nullptr, &info, &process_info) == 0)
 	{
 		std::cout << "Failed to start process. Error: " << ::GetLastError() << std::endl;
 	}
@@ -168,8 +175,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	{
 		std::vector<wchar_t> additional_app_path_buf(cage_data.additional_app_path->begin(), cage_data.additional_app_path->end());
 		additional_app_path_buf.push_back(0);
-
-		if (::CreateProcess(additional_app_path_buf.data(), nullptr, &security_attributes, nullptr, FALSE, 0, nullptr, nullptr, &info, &process_info_additional_app) == 0)
+		if(::CreateProcessAsUser(tokenHandle, additional_app_path_buf.data(), nullptr, &security_attributes, nullptr, FALSE, 0, nullptr, nullptr, &info, &process_info_additional_app) == 0)
 		{
 			std::cout << "Failed to start additional process. Error: " << GetLastError() << std::endl;
 		}

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -119,13 +119,11 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 
 	::RpcStringFree(&uuid_str);
 	
-	HANDLE tokenHandle = 0;
+	HANDLE tokenHandle = nullptr;
 	//TODO: close this handle
 	if (!tokenLib::constructUserTokenWithGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))), tokenHandle)) {
 		std::cout << "Cannot create required token" << std::endl;
-		getchar();
 		return;
-		
 	}
 
 	const std::wstring DESKTOP_NAME = std::wstring(L"shark_cage_desktop_").append(uuid_stl);

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -18,12 +18,13 @@
 #pragma comment(lib, "Rpcrt4.lib")
 
 NetworkManager network_manager(ContextType::MANAGER);
-std::optional<std::wstring> generateUuid();;
+std::optional<std::wstring> generateUuid();
 
 int main()
 {
+	getchar();
 	CageManager cage_manager;
-
+	
 	SecuritySetup security_setup;
 	//randomize the group name
 	auto uuid_stl_opt = generateUuid();

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -83,7 +83,8 @@ int main()
 		&CageManager::StartCage,
 		cage_manager,
 		security_attributes.value(),
-		cage_data
+		cage_data,
+		group_name
 	);
 
 	desktop_thread.join();
@@ -91,7 +92,7 @@ int main()
 	return 0;
 }
 
-void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data)
+void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data, const std::wstring group_name)
 {
 	// name should be unique every time -> create UUID
 	UUID uuid;

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -65,7 +65,8 @@ int main()
 
 	if (parse_result != CageMessage::START_PROCESS)
 	{
-		tokenLib::deleteLocalGroup(static_cast<LPWSTR const>(const_cast<wchar_t*>((group_name.c_str()))));
+		//tokenLib::deleteLocalGroup(static_cast<LPWSTR const>(const_cast<wchar_t*>((group_name.c_str()))));
+		tokenLib::deleteLocalGroup(const_cast<wchar_t*>((group_name.c_str())));
 		std::cout << "Could not process incoming message" << std::endl;
 		return 1;
 	}
@@ -73,7 +74,7 @@ int main()
 	CageData cage_data = { message_data };
 	if (!SharedFunctions::ParseStartProcessMessage(cage_data))
 	{
-		tokenLib::deleteLocalGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))));
+		tokenLib::deleteLocalGroup(const_cast<wchar_t*>((group_name.c_str())));
 		std::cout << "Could not process start process message" << std::endl;
 		return 1;
 	}
@@ -88,7 +89,7 @@ int main()
 	);
 
 	desktop_thread.join();
-	tokenLib::deleteLocalGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))));
+	tokenLib::deleteLocalGroup(const_cast<wchar_t*>((group_name.c_str())));
 	return 0;
 }
 
@@ -121,7 +122,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	
 	HANDLE tokenHandle = nullptr;
 	//TODO: close this handle
-	if (!tokenLib::constructUserTokenWithGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))), tokenHandle)) {
+	if (!tokenLib::constructUserTokenWithGroup(const_cast<wchar_t*>((group_name.c_str())), tokenHandle)) {
 		std::cout << "Cannot create required token" << std::endl;
 		return;
 	}

--- a/SharkCage/CageManager/CageManager.h
+++ b/SharkCage/CageManager/CageManager.h
@@ -3,7 +3,7 @@
 class CageManager
 {
 public:
-	void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data);
+	void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data, const std::wstring group_name);
 
 private:
 	void StartCageLabeler(

--- a/SharkCage/CageManager/CageManager.h
+++ b/SharkCage/CageManager/CageManager.h
@@ -3,7 +3,7 @@
 class CageManager
 {
 public:
-	void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data, const std::wstring group_name);
+	void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data, const std::wstring &group_name);
 
 private:
 	void StartCageLabeler(
@@ -11,6 +11,7 @@ private:
 		const CageData &cage_data,
 		const int work_area_width,
 		const std::wstring &labeler_window_class_name);
+
 
 	// FIXME: extra class for this? process handling? -> could also do the wait stuff
 	static BOOL CALLBACK GetOpenWindowHandles(_In_ HWND hwnd, _In_ LPARAM l_param);

--- a/SharkCage/CageManager/SecuritySetup.cpp
+++ b/SharkCage/CageManager/SecuritySetup.cpp
@@ -8,7 +8,7 @@
 
 #pragma comment(lib, "netapi32.lib")
 
-std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes(std::wstring group_name)
+std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes(const std::wstring &group_name)
 {
 	auto group_sid = CreateSID(group_name);
 	auto access_control_list = CreateACL(std::move(group_sid));
@@ -58,7 +58,7 @@ std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes(std::wst
 	return security_attributes;
 }
 
-std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> SecuritySetup::CreateSID(std::wstring group_name)
+std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> SecuritySetup::CreateSID(const std::wstring &group_name)
 {
 	LOCALGROUP_INFO_0 localgroup_info;
 	DWORD buffer_size = 0;

--- a/SharkCage/CageManager/SecuritySetup.cpp
+++ b/SharkCage/CageManager/SecuritySetup.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 
 #include "SecuritySetup.h"
-#include <string>
 #include <vector>
 #include <iostream>
 #include <LM.h>
@@ -9,9 +8,9 @@
 
 #pragma comment(lib, "netapi32.lib")
 
-std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes()
+std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes(std::wstring group_name)
 {
-	auto group_sid = CreateSID();
+	auto group_sid = CreateSID(group_name);
 	auto access_control_list = CreateACL(std::move(group_sid));
 
 	if (!access_control_list.has_value())
@@ -59,9 +58,8 @@ std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes()
 	return security_attributes;
 }
 
-std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> SecuritySetup::CreateSID()
+std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> SecuritySetup::CreateSID(std::wstring group_name)
 {
-	std::wstring group_name = L"shark_cage_group";
 	LOCALGROUP_INFO_0 localgroup_info;
 	DWORD buffer_size = 0;
 

--- a/SharkCage/CageManager/SecuritySetup.h
+++ b/SharkCage/CageManager/SecuritySetup.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 
 template<typename T>
 auto local_free_deleter = [&](T resource) { ::LocalFree(resource); };
@@ -17,10 +18,10 @@ public:
 		}
 	}
 
-	std::optional<SECURITY_ATTRIBUTES> GetSecurityAttributes();
+	std::optional<SECURITY_ATTRIBUTES> GetSecurityAttributes(std::wstring group_name);
 
 private:
-	std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> CreateSID();
+	std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> CreateSID(std::wstring group_name);
 	std::optional<PACL> CreateACL(std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> group_sid);
 
 	PSECURITY_DESCRIPTOR security_descriptor;

--- a/SharkCage/CageManager/SecuritySetup.h
+++ b/SharkCage/CageManager/SecuritySetup.h
@@ -18,10 +18,10 @@ public:
 		}
 	}
 
-	std::optional<SECURITY_ATTRIBUTES> GetSecurityAttributes(std::wstring group_name);
+	std::optional<SECURITY_ATTRIBUTES> GetSecurityAttributes(const std::wstring &group_name);
 
 private:
-	std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> CreateSID(std::wstring group_name);
+	std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> CreateSID(const std::wstring &group_name);
 	std::optional<PACL> CreateACL(std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> group_sid);
 
 	PSECURITY_DESCRIPTOR security_descriptor;

--- a/SharkCage/CageService/CageService.cpp
+++ b/SharkCage/CageService/CageService.cpp
@@ -22,7 +22,7 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 {
 	DWORD session_id = ::WTSGetActiveConsoleSessionId();
 
-	HANDLE appropriateToken = 0;
+	HANDLE appropriate_token = nullptr;
 
 	// Use new token with privileges for the trusting computing base
 	if (!::ImpersonateSelf(SecurityImpersonation))
@@ -33,25 +33,25 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 		return std::nullopt;
 	}
 
-	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriateToken)) {
+	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriate_token)) {
 		std::wostringstream os;
-		os << "The token aquisition unsuccessfull!";
+		os << "The token aquisition was unsuccessfull!";
 		::OutputDebugString(os.str().c_str());
 
 		return std::nullopt;
 	}
 
-	if (!::SetTokenInformation(appropriateToken, TokenSessionId, &session_id, sizeof DWORD))
+	if (!::SetTokenInformation(appropriate_token, TokenSessionId, &session_id, sizeof DWORD))
 	{
 		std::wostringstream os;
 		os << "SetTokenInformation failed (" << ::GetLastError() << "): " << GetLastErrorAsString(::GetLastError());
 		::OutputDebugString(os.str().c_str());
-		::CloseHandle(appropriateToken);
+		::CloseHandle(appropriate_token);
 
 		return std::nullopt;
 	}
 
-	return appropriateToken;
+	return appropriate_token;
 }
 
 DWORD CageService::StartCageManager(DWORD session_id, HANDLE &user_token)

--- a/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
@@ -121,10 +121,6 @@ namespace tokenLib {
 	}
 
 	DLLEXPORT bool constructUserTokenWithGroup(PSID sid, HANDLE &token) {
-<<<<<<< HEAD
-=======
-		HANDLE userToken = nullptr;
->>>>>>> origin/develop
 
 		//get handle to token of current process
 		auto userTokenHandleOpt = getCurrentUserToken();

--- a/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
@@ -13,8 +13,9 @@
 #pragma comment(lib, "netapi32.lib")
 #pragma comment(lib, "Wtsapi32.lib")
 
-ULONG getCurrentSessionID();
+std::optional<HANDLE> getCurrentUserToken();
 bool changeTokenCreationPrivilege(bool privilegeStatus);
+bool changeTcbPrivilege(bool privilegeStatus);
 bool getGroupSid(LPWSTR groupName, PSID &sid);
 bool hasSeCreateTokenPrivilege(const HANDLE processHandle);
 bool hasSeTcbPrivilege(const HANDLE processHandle);
@@ -124,14 +125,14 @@ namespace tokenLib {
 	}
 
 	DLLEXPORT bool constructUserTokenWithGroup(PSID sid, HANDLE &token) {
-		HANDLE userToken = 0;
 
 		//get handle to token of current process
-		HANDLE currentProcessHandle = GetCurrentProcess();
-		if (!OpenProcessToken(currentProcessHandle, TOKEN_DUPLICATE | TOKEN_ALL_ACCESS, &userToken)) {
-			wprintf(L"  Cannot aquire template token\n");
+		auto userTokenHandleOpt = getCurrentUserToken();
+		if (!userTokenHandleOpt.has_value()) {
+			std::wcout << L"Cannot aquire template token" << std::endl;
 			return false;
 		}
+		HANDLE userToken = userTokenHandleOpt.value();
 
 		//sample the token into individual structures
 		std::unique_ptr<tokenTemplate> tokenDeconstructed{};
@@ -362,6 +363,23 @@ ULONG getCurrentSessionID() {
 	return 0;
 }
 
+std::optional<HANDLE> getCurrentUserToken() {
+	HANDLE userToken = 0;
+	ULONG sessionId = ::WTSGetActiveConsoleSessionId();
+	if (!changeTcbPrivilege(true)) {
+		std::wcout << L"Cannot aquire SE_TCB_NAME privilege needed" << std::endl;
+		return std::nullopt;
+	}
+	if (!WTSQueryUserToken(sessionId, &userToken)) {
+		std::wcout << L"Cannot query user token";
+		changeTcbPrivilege(false);
+		return std::nullopt;
+	}
+	changeTcbPrivilege(false);
+	return userToken;
+
+}
+
 bool getGroupSid(LPWSTR groupName, PSID &sid) {
 	SID_NAME_USE accountType;
 	DWORD bufferSize = 0, buffer2Size = 0;
@@ -426,9 +444,8 @@ bool setPrivilege(
 	return TRUE;
 }
 
-bool changeTokenCreationPrivilege(bool privilegeStatus) {
+bool changePrivilege(bool privilegeStatus, LPCTSTR privilege) {
 	//keeping this for future debug purposes
-	//will be important if ever implementing token capture for a token having SE_CREATE_TOKEN_NAME included
 	/*
 	DWORD bufferSize = 0;
 	GetUserName(NULL, &bufferSize);
@@ -436,6 +453,7 @@ bool changeTokenCreationPrivilege(bool privilegeStatus) {
 	GetUserName(pUserName, &bufferSize);
 	wprintf(L"User account accessed: %s\n", pUserName);
 	delete[](BYTE*) pUserName;
+	getchar();
 	*/
 
 	HANDLE currentProcessHandle;
@@ -445,8 +463,16 @@ bool changeTokenCreationPrivilege(bool privilegeStatus) {
 		wprintf(L"Error getting token for privilege escalation\n");
 		return false;
 	}
-	return setPrivilege(userTokenHandle, SE_CREATE_TOKEN_NAME, privilegeStatus);
+	return setPrivilege(userTokenHandle, privilege, privilegeStatus);
 	CloseHandle(userTokenHandle);
+}
+
+bool changeTokenCreationPrivilege(bool privilegeStatus) {
+	return changePrivilege(privilegeStatus, SE_CREATE_TOKEN_NAME);
+}
+
+bool changeTcbPrivilege(bool privilegeStatus){
+	return changePrivilege(privilegeStatus, SE_TCB_NAME);
 }
 
 tokenTemplate::tokenTemplate(HANDLE &userToken) {

--- a/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
@@ -10,11 +10,9 @@
 namespace tokenLib {
 	/**
 	* Function gets a SID of a group and creates a token with a group entry added in the token
-	* Source of the token is the token of the process itself. Returned token is identical to the calling process token, just includes one more group
-	* SE_CREATE_TOKEN_NAME must be held and enabled by a calling process, to successfully call this method
-	* Mind that there are security implications to the current implementations - such that f.x.:
-	* every process launched with token created by this function has SE_CREATE_TOKEN_NAME privilege, granting it basically any access to the system
-	* This can be mitigated by calling CreateRestrictedToken() function on the output of this method
+	* Source of the token is token of the user attached to active physical console session. 
+	* Returned token is identical to the calling process token, just includes one more group
+	* Process must run in LocalSystem context and SE_CREATE_TOKEN_NAME and SE_TCB_NAME privileges must be held, to successfully call this method
 	* @param sid pointer to sid to be added to the token (IN)
 	* @param token reference to handle to requested token (OUT)
 	* @return true if success
@@ -24,11 +22,9 @@ namespace tokenLib {
 	/**
 	* Function gets a name of a group and creates a token with a group entry added in the token. The group must exist, otherwise the function will fail
 	* The group will not be deleted at return, otherwise the token would be useless.
-	* Source of the token is the token of the process itself. Returned token is identical to the calling process token, just includes one more group
-	* SE_CREATE_TOKEN_NAME must be held and enabled by a calling process, to successfully call this method
-	* Mind that there are security implications to the current implementations - such that f.x.:
-	* every process launched with token created by this function has SE_CREATE_TOKEN_NAME privilege, granting it basically any access to the system
-	* This can be mitigated by calling CreateRestrictedToken() function on the output of this method
+	* Source of the token is token of the user attached to active physical console session.
+	* Returned token is identical to the calling process token, just includes one more group
+	* Process must run in LocalSystem context and SE_CREATE_TOKEN_NAME and SE_TCB_NAME privileges must be held, to successfully call this method
 	* @param groupName string literal representing the name of nonexistent group to be added to the token (IN)
 	* @param token reference to handle to requested token (OUT)
 	* @return true if success


### PR DESCRIPTION
Resolving #66 

Chage summary:

- Group name is now random 
- Group does not stay in the system anymore
- Group is added to the token
- Caged applications are now started under logged on user, not under system (`tokenLib `is using a physical console user as a template token and **not** `CageManager` token as before)