### PR TITLE
Check access rights of config files before opening them

### DIFF
--- a/SharkCage/CageChooser/App.config
+++ b/SharkCage/CageChooser/App.config
@@ -1,18 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="CageChooser.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
-        </sectionGroup>
     </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
-    <userSettings>
-        <CageChooser.Properties.Settings>
-            <setting name="PersistentConfigPath" serializeAs="String">
-                <value />
-            </setting>
-        </CageChooser.Properties.Settings>
-    </userSettings>
 </configuration>

--- a/SharkCage/CageChooser/CageChooserForm.Designer.cs
+++ b/SharkCage/CageChooser/CageChooserForm.Designer.cs
@@ -28,52 +28,28 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.lruConfigs = new System.Windows.Forms.ListBox();
-            this.lruConfigsLabel = new System.Windows.Forms.Label();
-            this.configChooseLabel = new System.Windows.Forms.Label();
-            this.configBrowseButton = new System.Windows.Forms.Button();
+            this.registeredConfigs = new System.Windows.Forms.ListBox();
+            this.registeredConfigsLabel = new System.Windows.Forms.Label();
             this.openButton = new System.Windows.Forms.Button();
-            this.configPath = new System.Windows.Forms.TextBox();
             this.openCageConfiguratorButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
-            // lruConfigs
+            // registeredConfigs
             // 
-            this.lruConfigs.FormattingEnabled = true;
-            this.lruConfigs.Location = new System.Drawing.Point(16, 86);
-            this.lruConfigs.Name = "lruConfigs";
-            this.lruConfigs.Size = new System.Drawing.Size(446, 134);
-            this.lruConfigs.TabIndex = 4;
-            this.lruConfigs.SelectedIndexChanged += new System.EventHandler(this.lruConfigs_SelectedIndexChanged);
-            this.lruConfigs.KeyUp += new System.Windows.Forms.KeyEventHandler(this.lruConfigs_KeyUp);
+            this.registeredConfigs.FormattingEnabled = true;
+            this.registeredConfigs.Location = new System.Drawing.Point(16, 34);
+            this.registeredConfigs.Name = "registeredConfigs";
+            this.registeredConfigs.Size = new System.Drawing.Size(446, 186);
+            this.registeredConfigs.TabIndex = 4;
             // 
-            // lruConfigsLabel
+            // registeredConfigsLabel
             // 
-            this.lruConfigsLabel.AutoSize = true;
-            this.lruConfigsLabel.Location = new System.Drawing.Point(13, 70);
-            this.lruConfigsLabel.Name = "lruConfigsLabel";
-            this.lruConfigsLabel.Size = new System.Drawing.Size(147, 13);
-            this.lruConfigsLabel.TabIndex = 3;
-            this.lruConfigsLabel.Text = "Recently used configurations:";
-            // 
-            // configChooseLabel
-            // 
-            this.configChooseLabel.AutoSize = true;
-            this.configChooseLabel.Location = new System.Drawing.Point(13, 16);
-            this.configChooseLabel.Name = "configChooseLabel";
-            this.configChooseLabel.Size = new System.Drawing.Size(137, 13);
-            this.configChooseLabel.TabIndex = 0;
-            this.configChooseLabel.Text = "Selected config to execute:";
-            // 
-            // configBrowseButton
-            // 
-            this.configBrowseButton.Location = new System.Drawing.Point(366, 30);
-            this.configBrowseButton.Name = "configBrowseButton";
-            this.configBrowseButton.Size = new System.Drawing.Size(96, 24);
-            this.configBrowseButton.TabIndex = 2;
-            this.configBrowseButton.Text = "Browse ...";
-            this.configBrowseButton.UseVisualStyleBackColor = true;
-            this.configBrowseButton.Click += new System.EventHandler(this.configBrowseButton_Click);
+            this.registeredConfigsLabel.AutoSize = true;
+            this.registeredConfigsLabel.Location = new System.Drawing.Point(13, 16);
+            this.registeredConfigsLabel.Name = "registeredConfigsLabel";
+            this.registeredConfigsLabel.Size = new System.Drawing.Size(130, 13);
+            this.registeredConfigsLabel.TabIndex = 3;
+            this.registeredConfigsLabel.Text = "Registered configurations:";
             // 
             // openButton
             // 
@@ -84,16 +60,6 @@
             this.openButton.Text = "Start";
             this.openButton.UseVisualStyleBackColor = true;
             this.openButton.Click += new System.EventHandler(this.openButton_Click);
-            // 
-            // configPath
-            // 
-            this.configPath.DataBindings.Add(new System.Windows.Forms.Binding("Text", global::CageChooser.Properties.Settings.Default, "PersistentConfigPath", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.configPath.Location = new System.Drawing.Point(16, 32);
-            this.configPath.Name = "configPath";
-            this.configPath.Size = new System.Drawing.Size(340, 20);
-            this.configPath.TabIndex = 1;
-            this.configPath.Text = global::CageChooser.Properties.Settings.Default.PersistentConfigPath;
-            this.configPath.Leave += new System.EventHandler(this.configPath_Leave);
             // 
             // openCageConfiguratorButton
             // 
@@ -112,15 +78,11 @@
             this.ClientSize = new System.Drawing.Size(478, 276);
             this.Controls.Add(this.openCageConfiguratorButton);
             this.Controls.Add(this.openButton);
-            this.Controls.Add(this.configBrowseButton);
-            this.Controls.Add(this.configChooseLabel);
-            this.Controls.Add(this.configPath);
-            this.Controls.Add(this.lruConfigsLabel);
-            this.Controls.Add(this.lruConfigs);
+            this.Controls.Add(this.registeredConfigsLabel);
+            this.Controls.Add(this.registeredConfigs);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Name = "CageChooserForm";
             this.Text = "Cage Chooser";
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.CageChooser_FormClosed);
             this.Load += new System.EventHandler(this.CageChooser_Load);
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -128,11 +90,8 @@
         }
 
         #endregion
-        private System.Windows.Forms.ListBox lruConfigs;
-        private System.Windows.Forms.Label lruConfigsLabel;
-        private System.Windows.Forms.TextBox configPath;
-        private System.Windows.Forms.Label configChooseLabel;
-        private System.Windows.Forms.Button configBrowseButton;
+        private System.Windows.Forms.ListBox registeredConfigs;
+        private System.Windows.Forms.Label registeredConfigsLabel;
         private System.Windows.Forms.Button openButton;
         private System.Windows.Forms.Button openCageConfiguratorButton;
     }

--- a/SharkCage/CageChooser/CageChooserForm.Designer.cs
+++ b/SharkCage/CageChooser/CageChooserForm.Designer.cs
@@ -91,7 +91,9 @@
             this.Controls.Add(this.registeredConfigsLabel);
             this.Controls.Add(this.registeredConfigs);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
             this.Name = "CageChooserForm";
+            this.ShowIcon = false;
             this.Text = "Cage Chooser";
             this.Load += new System.EventHandler(this.CageChooser_Load);
             this.ResumeLayout(false);

--- a/SharkCage/CageChooser/CageChooserForm.Designer.cs
+++ b/SharkCage/CageChooser/CageChooserForm.Designer.cs
@@ -28,10 +28,12 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.registeredConfigs = new System.Windows.Forms.ListBox();
             this.registeredConfigsLabel = new System.Windows.Forms.Label();
             this.openButton = new System.Windows.Forms.Button();
             this.openCageConfiguratorButton = new System.Windows.Forms.Button();
+            this.refreshTooltip = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 
             // registeredConfigs
@@ -41,6 +43,8 @@
             this.registeredConfigs.Name = "registeredConfigs";
             this.registeredConfigs.Size = new System.Drawing.Size(446, 186);
             this.registeredConfigs.TabIndex = 4;
+            this.refreshTooltip.SetToolTip(this.registeredConfigs, "Press F5 to refresh this list");
+            this.registeredConfigs.SelectedIndexChanged += new System.EventHandler(this.registeredConfigs_SelectedIndexChanged);
             // 
             // registeredConfigsLabel
             // 
@@ -71,6 +75,12 @@
             this.openCageConfiguratorButton.UseVisualStyleBackColor = true;
             this.openCageConfiguratorButton.Click += new System.EventHandler(this.openCageConfiguratorButton_Click);
             // 
+            // refreshTooltip
+            // 
+            this.refreshTooltip.AutoPopDelay = 30000;
+            this.refreshTooltip.InitialDelay = 500;
+            this.refreshTooltip.ReshowDelay = 100;
+            // 
             // CageChooserForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -94,6 +104,7 @@
         private System.Windows.Forms.Label registeredConfigsLabel;
         private System.Windows.Forms.Button openButton;
         private System.Windows.Forms.Button openCageConfiguratorButton;
+        private System.Windows.Forms.ToolTip refreshTooltip;
     }
 }
 

--- a/SharkCage/CageChooser/CageChooserForm.cs
+++ b/SharkCage/CageChooser/CageChooserForm.cs
@@ -29,6 +29,14 @@ namespace CageChooser
 
         private void CageChooser_Load(object sender, EventArgs e)
         {
+            LoadConfigList();
+        }
+
+        private void LoadConfigList()
+        {
+            config_name_value_mapping.Clear();
+            registeredConfigs.Items.Clear();
+
             var subkey = REGISTRY_KEY.Replace("HKEY_LOCAL_MACHINE\\", "");
             var config_registry_key = Path.Combine(subkey, "Configs");
             var key = Registry.LocalMachine.OpenSubKey(config_registry_key, false);
@@ -41,7 +49,30 @@ namespace CageChooser
                     config_name_value_mapping.Add(value_name, value);
                     registeredConfigs.Items.Insert(registeredConfigs.Items.Count, value_name);
                 }
+
+                if (registeredConfigs.Items.Count > 0)
+                {
+                    registeredConfigs.SelectedIndex = 0;
+                }
             }
+
+            openButton.Enabled = registeredConfigs.SelectedItem != null;
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            bool bHandled = false;
+            switch (keyData)
+            {
+                case Keys.F5:
+                    LoadConfigList();
+
+                    bHandled = true;
+                    break;
+                default:
+                    return base.ProcessCmdKey(ref msg, keyData);
+            }
+            return bHandled;
         }
 
         #endregion
@@ -86,14 +117,22 @@ namespace CageChooser
 
             var p = new System.Diagnostics.Process();
             p.StartInfo.FileName = $@"{install_dir}\CageConfigurator.exe";
+
             var selected_item = registeredConfigs.SelectedItem?.ToString() ?? String.Empty;
-            if (selected_item != String.Empty)
+            var config_path = String.Empty;
+            config_name_value_mapping.TryGetValue(selected_item, out config_path);
+            if (config_path != String.Empty)
             {
-                p.StartInfo.Arguments = $@"""{selected_item}""";
+                p.StartInfo.Arguments = $@"""{config_path}""";
             }
             p.Start();
         }
 
         #endregion
+
+        private void registeredConfigs_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            openButton.Enabled = registeredConfigs.SelectedItem != null;
+        }
     }
 }

--- a/SharkCage/CageChooser/CageChooserForm.cs
+++ b/SharkCage/CageChooser/CageChooserForm.cs
@@ -68,6 +68,12 @@ namespace CageChooser
             bool bHandled = false;
             switch (keyData)
             {
+                case Keys.Enter:
+                    if (registeredConfigs.SelectedItem != null)
+                    {
+                        SendToCage();
+                    }
+                    break;
                 case Keys.F5:
                     LoadConfigList();
 
@@ -83,7 +89,7 @@ namespace CageChooser
 
         #region Cage Service
 
-        private void openButton_Click(object sender, EventArgs e)
+        private void SendToCage()
         {
             try
             {
@@ -96,7 +102,7 @@ namespace CageChooser
                     int capacity = 1000;
                     StringBuilder sb = new StringBuilder(capacity);
 
-                    bool result = NativeMethods.SendConfigAndExternalProgram(configPath.Text, sb, capacity);
+                    bool result = NativeMethods.SendConfigAndExternalProgram(config_path, sb, capacity);
 
                     if (!result)
                     {
@@ -111,6 +117,11 @@ namespace CageChooser
             {
                 MessageBox.Show($"An exception occured while trying to send messages to cage service: {ex.ToString()}");
             }
+        }
+
+        private void openButton_Click(object sender, EventArgs e)
+        {
+            SendToCage();
         }
 
         #endregion

--- a/SharkCage/CageChooser/CageChooserForm.resx
+++ b/SharkCage/CageChooser/CageChooserForm.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="refreshTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/SharkCage/CageChooser/CageChooserForm.resx
+++ b/SharkCage/CageChooser/CageChooserForm.resx
@@ -120,4 +120,7 @@
   <metadata name="refreshTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="refreshTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/SharkCage/CageChooser/Properties/Settings.Designer.cs
+++ b/SharkCage/CageChooser/Properties/Settings.Designer.cs
@@ -22,28 +22,5 @@ namespace CageChooser.Properties {
                 return defaultInstance;
             }
         }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string PersistentConfigPath {
-            get {
-                return ((string)(this["PersistentConfigPath"]));
-            }
-            set {
-                this["PersistentConfigPath"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        public global::System.Collections.Specialized.StringCollection PersistentLRUConfigs {
-            get {
-                return ((global::System.Collections.Specialized.StringCollection)(this["PersistentLRUConfigs"]));
-            }
-            set {
-                this["PersistentLRUConfigs"] = value;
-            }
-        }
     }
 }

--- a/SharkCage/CageChooser/Properties/Settings.settings
+++ b/SharkCage/CageChooser/Properties/Settings.settings
@@ -1,12 +1,5 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="CageChooser.Properties" GeneratedClassName="Settings">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)">
   <Profiles />
-  <Settings>
-    <Setting Name="PersistentConfigPath" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
-    </Setting>
-    <Setting Name="PersistentLRUConfigs" Type="System.Collections.Specialized.StringCollection" Scope="User">
-      <Value Profile="(Default)" />
-    </Setting>
-  </Settings>
+  <Settings />
 </SettingsFile>

--- a/SharkCage/CageConfigurator/CageConfiguratorForm.Designer.cs
+++ b/SharkCage/CageConfigurator/CageConfiguratorForm.Designer.cs
@@ -47,13 +47,15 @@
             this.videoSources = new System.Windows.Forms.ComboBox();
             this.restrictExitButton = new System.Windows.Forms.CheckBox();
             this.restrictExitTooltip = new System.Windows.Forms.ToolTip(this.components);
+            this.configNameLabel = new System.Windows.Forms.Label();
+            this.configName = new System.Windows.Forms.TextBox();
             this.menuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.tokenBox)).BeginInit();
             this.SuspendLayout();
             // 
             // openCageChooserButton
             // 
-            this.openCageChooserButton.Location = new System.Drawing.Point(12, 445);
+            this.openCageChooserButton.Location = new System.Drawing.Point(12, 485);
             this.openCageChooserButton.Name = "openCageChooserButton";
             this.openCageChooserButton.Size = new System.Drawing.Size(221, 24);
             this.openCageChooserButton.TabIndex = 10;
@@ -72,11 +74,11 @@
             // 
             // saveButton
             // 
-            this.saveButton.Location = new System.Drawing.Point(251, 445);
+            this.saveButton.Location = new System.Drawing.Point(251, 485);
             this.saveButton.Name = "saveButton";
             this.saveButton.Size = new System.Drawing.Size(221, 24);
             this.saveButton.TabIndex = 11;
-            this.saveButton.Text = "Save configuration ...";
+            this.saveButton.Text = "Save configuration";
             this.saveButton.UseVisualStyleBackColor = true;
             this.saveButton.Click += new System.EventHandler(this.saveButton_Click);
             // 
@@ -117,6 +119,7 @@
             // 
             // applicationPath
             // 
+            this.applicationPath.AllowDrop = true;
             this.applicationPath.Location = new System.Drawing.Point(12, 56);
             this.applicationPath.Name = "applicationPath";
             this.applicationPath.Size = new System.Drawing.Size(354, 20);
@@ -214,11 +217,30 @@
             this.restrictExitTooltip.ReshowDelay = 100;
             this.restrictExitTooltip.Tag = "";
             // 
+            // configNameLabel
+            // 
+            this.configNameLabel.AutoSize = true;
+            this.configNameLabel.Location = new System.Drawing.Point(13, 430);
+            this.configNameLabel.Name = "configNameLabel";
+            this.configNameLabel.Size = new System.Drawing.Size(114, 13);
+            this.configNameLabel.TabIndex = 12;
+            this.configNameLabel.Text = "Name of configuration:";
+            // 
+            // configName
+            // 
+            this.configName.Location = new System.Drawing.Point(12, 446);
+            this.configName.Name = "configName";
+            this.configName.Size = new System.Drawing.Size(460, 20);
+            this.configName.TabIndex = 13;
+            this.configName.TextChanged += new System.EventHandler(this.configName_TextChanged);
+            // 
             // CageConfiguratorForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(484, 481);
+            this.ClientSize = new System.Drawing.Size(484, 521);
+            this.Controls.Add(this.configName);
+            this.Controls.Add(this.configNameLabel);
             this.Controls.Add(this.restrictExitButton);
             this.Controls.Add(this.videoSources);
             this.Controls.Add(this.tokenBox);
@@ -265,6 +287,8 @@
         private System.Windows.Forms.ComboBox videoSources;
         private System.Windows.Forms.CheckBox restrictExitButton;
         private System.Windows.Forms.ToolTip restrictExitTooltip;
+        private System.Windows.Forms.Label configNameLabel;
+        private System.Windows.Forms.TextBox configName;
     }
 }
 

--- a/SharkCage/CageConfigurator/CageConfiguratorForm.Designer.cs
+++ b/SharkCage/CageConfigurator/CageConfiguratorForm.Designer.cs
@@ -49,6 +49,7 @@
             this.restrictExitTooltip = new System.Windows.Forms.ToolTip(this.components);
             this.configNameLabel = new System.Windows.Forms.Label();
             this.configName = new System.Windows.Forms.TextBox();
+            this.saveLabel = new System.Windows.Forms.Label();
             this.menuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.tokenBox)).BeginInit();
             this.SuspendLayout();
@@ -234,11 +235,23 @@
             this.configName.TabIndex = 13;
             this.configName.TextChanged += new System.EventHandler(this.configName_TextChanged);
             // 
+            // saveLabel
+            // 
+            this.saveLabel.AutoSize = true;
+            this.saveLabel.ForeColor = System.Drawing.Color.LimeGreen;
+            this.saveLabel.Location = new System.Drawing.Point(326, 470);
+            this.saveLabel.Name = "saveLabel";
+            this.saveLabel.Size = new System.Drawing.Size(72, 13);
+            this.saveLabel.TabIndex = 14;
+            this.saveLabel.Text = "Config saved!";
+            this.saveLabel.Visible = false;
+            // 
             // CageConfiguratorForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(484, 521);
+            this.Controls.Add(this.saveLabel);
             this.Controls.Add(this.configName);
             this.Controls.Add(this.configNameLabel);
             this.Controls.Add(this.restrictExitButton);
@@ -257,7 +270,9 @@
             this.Controls.Add(this.menuStrip);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.MainMenuStrip = this.menuStrip;
+            this.MaximizeBox = false;
             this.Name = "CageConfiguratorForm";
+            this.ShowIcon = false;
             this.Text = "Cage Configurator";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.CageConfiguratorForm_FormClosing);
             this.menuStrip.ResumeLayout(false);
@@ -289,6 +304,7 @@
         private System.Windows.Forms.ToolTip restrictExitTooltip;
         private System.Windows.Forms.Label configNameLabel;
         private System.Windows.Forms.TextBox configName;
+        private System.Windows.Forms.Label saveLabel;
     }
 }
 

--- a/SharkCage/CageConfigurator/CageConfiguratorForm.cs
+++ b/SharkCage/CageConfigurator/CageConfiguratorForm.cs
@@ -14,6 +14,8 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace CageConfigurator
@@ -496,6 +498,22 @@ namespace CageConfigurator
                     stream_writer.Write(sb.ToString());
                 }
             }
+
+            // make the save label appear and disappear again (async)
+            Task.Run(() =>
+            {
+                // invoke has to be used so the control property is changed
+                // on the same thread as the control was created from
+                saveLabel.Invoke((Action)(() =>
+                {
+                    saveLabel.Visible = true;
+                }));
+                Thread.Sleep(3000);
+                saveLabel.Invoke((Action)(() =>
+                {
+                    saveLabel.Visible = false;
+                }));
+            });
 
             var config_registry_key = Path.Combine(REGISTRY_KEY, "Configs");
             Registry.SetValue(config_registry_key, configName.Text, file_name);

--- a/SharkCage/CageConfigurator/CageConfiguratorForm.cs
+++ b/SharkCage/CageConfigurator/CageConfiguratorForm.cs
@@ -166,7 +166,7 @@ namespace CageConfigurator
         {
             if (unsaved_data)
             {
-                var contine_unsaved = MessageBox.Show("There are unsaved changes. Do you want to continue?", "Sharc Cage", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                var contine_unsaved = MessageBox.Show("There are unsaved changes. Do you want to continue?", "SharkCage", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                 if (contine_unsaved == DialogResult.No)
                 {
                     return;
@@ -180,7 +180,7 @@ namespace CageConfigurator
         {
             if (unsaved_data)
             {
-                var contine_unsaved = MessageBox.Show("There are unsaved changes. Do you want to continue?", "Sharc Cage", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                var contine_unsaved = MessageBox.Show("There are unsaved changes. Do you want to continue?", "SharkCage", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
                 if (contine_unsaved == DialogResult.No)
                 {
                     return;
@@ -202,6 +202,23 @@ namespace CageConfigurator
 
         private void LoadConfig(string config_path)
         {
+            IdentityReference built_in_administrators = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+            var file_security = new FileSecurity(config_path, AccessControlSections.Access);
+
+            var access_rules = file_security.GetAccessRules(true, true, typeof(SecurityIdentifier));
+            var access_rules_okay = access_rules.Count == 1;
+            foreach (AuthorizationRule access_rule in access_rules)
+            {
+                access_rules_okay = access_rules_okay && access_rule.IdentityReference == built_in_administrators;
+            }
+
+            if (!access_rules_okay)
+            {
+                MessageBox.Show("The config you are trying to load does not have the correct access rights, " +
+                    "it might be corrupted or a potential attacker has modified it.", "SharkCage", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
+                return;
+            }
+
             try
             {
                 var json = JObject.Parse(File.ReadAllText(config_path));
@@ -218,6 +235,7 @@ namespace CageConfigurator
                 current_config_name = Path.GetFileNameWithoutExtension(config_path);
                 configName.Text = current_config_name;
                 Text = $"Cage Configurator - {current_config_name}";
+                SetUnsavedData(false);
             }
             catch (Exception e)
             {

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -22,17 +22,6 @@ NetworkManager network_manager(ContextType::MANAGER);
 
 int main()
 {
-	CageManager cage_manager;
-
-	SecuritySetup security_setup;
-	auto security_attributes = security_setup.GetSecurityAttributes();
-
-	if (!security_attributes.has_value())
-	{
-		std::cout << "Could not get security attributes" << std::endl;
-		return 1;
-	}
-
 	// listen for the message
 	std::wstring message = network_manager.Listen(10);
 	std::wstring message_data;
@@ -52,6 +41,7 @@ int main()
 		return 1;
 	}
 
+	CageManager cage_manager;
 	if (cage_manager.ProcessRunning(cage_data.app_path) || (cage_data.hasAdditionalAppInfo() && cage_manager.ProcessRunning(cage_data.additional_app_path.value())))
 	{
 		std::wstring result_data;
@@ -63,6 +53,15 @@ int main()
 
 	std::wstring result_data;
 	network_manager.Send(sender, CageMessage::RESPONSE_SUCCESS, L"", result_data);
+
+	SecuritySetup security_setup;
+	auto security_attributes = security_setup.GetSecurityAttributes();
+
+	if (!security_attributes.has_value())
+	{
+		std::cout << "Could not get security attributes" << std::endl;
+		return 1;
+	}
 
 	const int work_area_width = 300;
 	std::thread desktop_thread(

--- a/SharkCage/CageService/CageService.cpp
+++ b/SharkCage/CageService/CageService.cpp
@@ -199,7 +199,8 @@ void CageService::HandleMessage(const std::wstring &message, NetworkManager &net
 		os << L"received unknown message: " << message << std::endl;
 		::OutputDebugString(os.str().c_str());
 
-		// fixme send response failure to chooser
+		std::wstring result_data;
+		network_manager.Send(sender, CageMessage::RESPONSE_FAILURE, os.str(), result_data);
 		return;
 	}
 
@@ -209,7 +210,8 @@ void CageService::HandleMessage(const std::wstring &message, NetworkManager &net
 		os << L"Another cage instance is already running" << std::endl;
 		::OutputDebugString(os.str().c_str());
 
-		// fixme send reponse failure to chooser
+		std::wstring result_data;
+		network_manager.Send(sender, CageMessage::RESPONSE_FAILURE, os.str(), result_data);
 		return;
 	}
 
@@ -219,7 +221,8 @@ void CageService::HandleMessage(const std::wstring &message, NetworkManager &net
 		os << L"The config you are trying to load does not have the correct access rights, it might be corrupted or a potential attacker has modified it." << std::endl;
 		::OutputDebugString(os.str().c_str());
 
-		// fixme send reponse failure to chooser
+		std::wstring result_data;
+		network_manager.Send(sender, CageMessage::RESPONSE_FAILURE, os.str(), result_data);
 		return;
 	}
 

--- a/SharkCage/CageService/CageService.h
+++ b/SharkCage/CageService/CageService.h
@@ -55,4 +55,6 @@ private:
 	std::wstring GetLastErrorAsString(DWORD error_id);
 
 	std::optional<HANDLE> CageService::CreateImpersonatingUserToken();
+
+	bool CheckConfigAccessRights(const std::wstring config_path);
 };


### PR DESCRIPTION
fixes #75 

* `Configurator` and `Service` now check the access rights of the config file before opening / processing them further
* The list of available configs in the `Chooser` is now based on registry entries written by the `Configurator`
* Configs are now all stored in the same folder to make it less likely a registry entry gets invalidated

@bencikpeter Could you take a look at the `CheckConfigAccessRights` function in the `CageService`? You have the most experience with the Windows API in this regard
https://github.com/SharkCagey/HTWG_shark_cage/pull/85/files#diff-c70ab997f5ee033d6f6d8bd7ca7264b8R243