### PR TITLE
66 Starting caged applications under correct privileges

### DIFF
--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -108,7 +108,8 @@ int main()
 		&CageManager::StartCage,
 		cage_manager,
 		security_attributes.value(),
-		cage_data
+		cage_data,
+		group_name
 	);
 
 	desktop_thread.join();
@@ -116,7 +117,7 @@ int main()
 	return 0;
 }
 
-void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data)
+void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data, const std::wstring group_name)
 {
 	// name should be unique every time -> create UUID
 	UUID uuid;

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -3,6 +3,7 @@
 #include "../SharedFunctionality/NetworkManager.h"
 #include "../SharedFunctionality/SharedFunctions.h"
 #include "../SharedFunctionality/CageData.h"
+#include "../SharedFunctionality/tokenLib/groupManipulation.h"
 
 #include "Aclapi.h"
 #include "tlhelp32.h"
@@ -67,6 +68,7 @@ int main()
 
 	if (parse_result != CageMessage::START_PROCESS)
 	{
+		tokenLib::deleteLocalGroup(static_cast<LPWSTR const>(const_cast<wchar_t*>((group_name.c_str()))));
 		std::cout << "Could not process incoming message" << std::endl;
 		return 1;
 	}
@@ -74,6 +76,7 @@ int main()
 	CageData cage_data = { message_data };
 	if (!SharedFunctions::ParseStartProcessMessage(cage_data))
 	{
+		tokenLib::deleteLocalGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))));
 		std::cout << "Could not process start process message" << std::endl;
 		return 1;
 	}
@@ -109,7 +112,7 @@ int main()
 	);
 
 	desktop_thread.join();
-
+	tokenLib::deleteLocalGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))));
 	return 0;
 }
 

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -68,7 +68,8 @@ int main()
 
 	if (parse_result != CageMessage::START_PROCESS)
 	{
-		tokenLib::deleteLocalGroup(static_cast<LPWSTR const>(const_cast<wchar_t*>((group_name.c_str()))));
+		//tokenLib::deleteLocalGroup(static_cast<LPWSTR const>(const_cast<wchar_t*>((group_name.c_str()))));
+		tokenLib::deleteLocalGroup(const_cast<wchar_t*>((group_name.c_str())));
 		std::cout << "Could not process incoming message" << std::endl;
 		return 1;
 	}
@@ -76,7 +77,7 @@ int main()
 	CageData cage_data = { message_data };
 	if (!SharedFunctions::ParseStartProcessMessage(cage_data))
 	{
-		tokenLib::deleteLocalGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))));
+		tokenLib::deleteLocalGroup(const_cast<wchar_t*>((group_name.c_str())));
 		std::cout << "Could not process start process message" << std::endl;
 		return 1;
 	}
@@ -113,7 +114,7 @@ int main()
 	);
 
 	desktop_thread.join();
-	tokenLib::deleteLocalGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))));
+	tokenLib::deleteLocalGroup(const_cast<wchar_t*>((group_name.c_str())));
 	return 0;
 }
 
@@ -146,7 +147,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 
 	HANDLE tokenHandle = nullptr;
 	//TODO: close this handle
-	if (!tokenLib::constructUserTokenWithGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))), tokenHandle)) {
+	if (!tokenLib::constructUserTokenWithGroup(const_cast<wchar_t*>((group_name.c_str())), tokenHandle)) {
 		std::cout << "Cannot create required token" << std::endl;
 		return;
 	}

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -22,6 +22,19 @@ NetworkManager network_manager(ContextType::MANAGER);
 
 int main()
 {
+	CageManager cage_manager;
+
+	SecuritySetup security_setup;
+	//TODO randomize the group name
+	std::wstring group_name = L"Shark_cage_test_group";
+	auto security_attributes = security_setup.GetSecurityAttributes(group_name);
+
+	if (!security_attributes.has_value())
+	{
+		std::cout << "Could not get security attributes" << std::endl;
+		return 1;
+	}
+
 	// listen for the message
 	std::wstring message = network_manager.Listen(10);
 	std::wstring message_data;
@@ -269,7 +282,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	}
 
 	// we can't rely on the process handles to keep track of open processes on
-	// the secure desktop as programs (e.g. Internet Explorer) spawn multiple processes and 
+	// the secure desktop as programs (e.g. Internet Explorer) spawn multiple processes and
 	// maybe even close the initial process we spawned ourselves
 	// Solution: enumerate all top level windows on the desktop not belonging to our
 	// process and message these handles

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -150,7 +150,8 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	}
 	auto uuid_stl = uuid_stl_opt.value();
 	HANDLE token_handle = nullptr;
-	if (!tokenLib::constructUserTokenWithGroup(const_cast<wchar_t*>((group_name.c_str())), token_handle)) {
+	if (!tokenLib::constructUserTokenWithGroup(const_cast<wchar_t*>((group_name.c_str())), token_handle))
+	{
 		std::cout << "Cannot create required token" << std::endl;
 		return;
 	}

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -24,7 +24,6 @@ std::optional<std::wstring> generateUuid();
 
 int main()
 {
-	getchar();
 	CageManager cage_manager;
 	
 	SecuritySetup security_setup;
@@ -151,7 +150,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	// Create the process.
 	PROCESS_INFORMATION process_info = {};
 
-	if (::CreateProcessAsUser(tokenHandle, path_buf.data(), nullptr, &security_attributes, nullptr, false, 0, nullptr, nullptr, &info, &process_info) == 0)
+	if(::CreateProcessWithTokenW(tokenHandle,LOGON_WITH_PROFILE,path_buf.data(),nullptr,0,nullptr,nullptr,&info, &process_info) == 0)
 	{
 		std::cout << "Failed to start process. Error: " << ::GetLastError() << std::endl;
 	}
@@ -161,7 +160,8 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	{
 		std::vector<wchar_t> additional_app_path_buf(cage_data.additional_app_path->begin(), cage_data.additional_app_path->end());
 		additional_app_path_buf.push_back(0);
-		if(::CreateProcessAsUser(tokenHandle, additional_app_path_buf.data(), nullptr, &security_attributes, nullptr, FALSE, 0, nullptr, nullptr, &info, &process_info_additional_app) == 0)
+
+		if (::CreateProcessWithTokenW(tokenHandle, LOGON_WITH_PROFILE, additional_app_path_buf.data(), nullptr, 0, nullptr, nullptr, &info, &process_info_additional_app) == 0)
 		{
 			std::cout << "Failed to start additional process. Error: " << GetLastError() << std::endl;
 		}

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -99,9 +99,9 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 		return;
 	}
 	auto uuid_stl = uuid_stl_opt.value();
-	HANDLE tokenHandle = nullptr;
+	HANDLE token_handle = nullptr;
 	//TODO: close this handle
-	if (!tokenLib::constructUserTokenWithGroup(const_cast<wchar_t*>((group_name.c_str())), tokenHandle)) {
+	if (!tokenLib::constructUserTokenWithGroup(const_cast<wchar_t*>((group_name.c_str())), token_handle)) {
 		std::cout << "Cannot create required token" << std::endl;
 		return;
 	}
@@ -141,7 +141,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	// Create the process.
 	PROCESS_INFORMATION process_info = {};
 
-	if(::CreateProcessWithTokenW(tokenHandle,LOGON_WITH_PROFILE, cage_data.app_path.c_str(),nullptr,0,nullptr,nullptr,&info, &process_info) == 0)
+	if(::CreateProcessWithTokenW(token_handle,LOGON_WITH_PROFILE, cage_data.app_path.c_str(),nullptr,0,nullptr,nullptr,&info, &process_info) == 0)
 	{
 		std::cout << "Failed to start process. Error: " << ::GetLastError() << std::endl;
 	}
@@ -149,7 +149,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	PROCESS_INFORMATION process_info_additional_app = { 0 };
 	if (cage_data.hasAdditionalAppInfo())
 	{
-		if (::CreateProcessWithTokenW(tokenHandle, LOGON_WITH_PROFILE, cage_data.additional_app_path.value().c_str(), nullptr, 0, nullptr, nullptr, &info, &process_info_additional_app) == 0)
+		if (::CreateProcessWithTokenW(token_handle, LOGON_WITH_PROFILE, cage_data.additional_app_path.value().c_str(), nullptr, 0, nullptr, nullptr, &info, &process_info_additional_app) == 0)
 		{
 			std::cout << "Failed to start additional process. Error: " << GetLastError() << std::endl;
 		}
@@ -199,7 +199,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 						if (*iterator == cage_data.activate_app)
 						{
 							CageManager::ActivateApp(
-								tokenHandle,
+								token_handle,
 								cage_data.app_path,
 								cage_data.activate_app,
 								desktop_handle,
@@ -211,7 +211,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 						else if (cage_data.hasAdditionalAppInfo() && *iterator == cage_data.activate_additional_app.value())
 						{
 							CageManager::ActivateApp(
-								tokenHandle,
+								token_handle,
 								cage_data.additional_app_path.value(),
 								cage_data.activate_additional_app.value(),
 								desktop_handle,
@@ -421,7 +421,7 @@ bool CageManager::ProcessRunning(const std::wstring &process_path)
 }
 
 void CageManager::ActivateApp(
-	const HANDLE tokenHandle,
+	const HANDLE token_handle,
 	const std::wstring &path,
 	const HANDLE &event,
 	const HDESK &desktop_handle,
@@ -450,7 +450,7 @@ void CageManager::ActivateApp(
 		::CloseHandle(process_info.hProcess);
 		::CloseHandle(process_info.hThread);
 
-		if(::CreateProcessWithTokenW(tokenHandle, LOGON_WITH_PROFILE, path.c_str(), nullptr, 0, nullptr, nullptr, &info, &process_info))
+		if(::CreateProcessWithTokenW(token_handle, LOGON_WITH_PROFILE, path.c_str(), nullptr, 0, nullptr, nullptr, &info, &process_info))
 		{
 			std::cout << "Failed to start process. Error: " << ::GetLastError() << std::endl;
 		}

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -64,7 +64,6 @@ int main()
 		return 1;
 	}
 
-	CageManager cage_manager;
 	if (cage_manager.ProcessRunning(cage_data.app_path) || (cage_data.hasAdditionalAppInfo() && cage_manager.ProcessRunning(cage_data.additional_app_path.value())))
 	{
 		std::wstring result_data;
@@ -77,14 +76,6 @@ int main()
 	std::wstring result_data;
 	network_manager.Send(sender, CageMessage::RESPONSE_SUCCESS, L"", result_data);
 
-	SecuritySetup security_setup;
-	auto security_attributes = security_setup.GetSecurityAttributes();
-
-	if (!security_attributes.has_value())
-	{
-		std::cout << "Could not get security attributes" << std::endl;
-		return 1;
-	}
 
 	const int work_area_width = 300;
 	std::thread desktop_thread(
@@ -150,7 +141,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	// Create the process.
 	PROCESS_INFORMATION process_info = {};
 
-	if(::CreateProcessWithTokenW(tokenHandle,LOGON_WITH_PROFILE,path_buf.data(),nullptr,0,nullptr,nullptr,&info, &process_info) == 0)
+	if(::CreateProcessWithTokenW(tokenHandle,LOGON_WITH_PROFILE, cage_data.app_path.c_str(),nullptr,0,nullptr,nullptr,&info, &process_info) == 0)
 	{
 		std::cout << "Failed to start process. Error: " << ::GetLastError() << std::endl;
 	}
@@ -158,10 +149,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 	PROCESS_INFORMATION process_info_additional_app = { 0 };
 	if (cage_data.hasAdditionalAppInfo())
 	{
-		std::vector<wchar_t> additional_app_path_buf(cage_data.additional_app_path->begin(), cage_data.additional_app_path->end());
-		additional_app_path_buf.push_back(0);
-
-		if (::CreateProcessWithTokenW(tokenHandle, LOGON_WITH_PROFILE, additional_app_path_buf.data(), nullptr, 0, nullptr, nullptr, &info, &process_info_additional_app) == 0)
+		if (::CreateProcessWithTokenW(tokenHandle, LOGON_WITH_PROFILE, cage_data.additional_app_path.value().c_str(), nullptr, 0, nullptr, nullptr, &info, &process_info_additional_app) == 0)
 		{
 			std::cout << "Failed to start additional process. Error: " << GetLastError() << std::endl;
 		}

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -199,6 +199,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 						if (*iterator == cage_data.activate_app)
 						{
 							CageManager::ActivateApp(
+								tokenHandle,
 								cage_data.app_path,
 								cage_data.activate_app,
 								desktop_handle,
@@ -210,6 +211,7 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 						else if (cage_data.hasAdditionalAppInfo() && *iterator == cage_data.activate_additional_app.value())
 						{
 							CageManager::ActivateApp(
+								tokenHandle,
 								cage_data.additional_app_path.value(),
 								cage_data.activate_additional_app.value(),
 								desktop_handle,
@@ -419,6 +421,7 @@ bool CageManager::ProcessRunning(const std::wstring &process_path)
 }
 
 void CageManager::ActivateApp(
+	const HANDLE tokenHandle,
 	const std::wstring &path,
 	const HANDLE &event,
 	const HDESK &desktop_handle,
@@ -447,17 +450,7 @@ void CageManager::ActivateApp(
 		::CloseHandle(process_info.hProcess);
 		::CloseHandle(process_info.hThread);
 
-		if (::CreateProcess(
-			path.c_str(),
-			nullptr,
-			&security_attributes,
-			nullptr,
-			FALSE,
-			0,
-			nullptr,
-			nullptr,
-			&info,
-			&process_info) == 0)
+		if(::CreateProcessWithTokenW(tokenHandle, LOGON_WITH_PROFILE, path.c_str(), nullptr, 0, nullptr, nullptr, &info, &process_info))
 		{
 			std::cout << "Failed to start process. Error: " << ::GetLastError() << std::endl;
 		}

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -25,8 +25,32 @@ int main()
 	CageManager cage_manager;
 
 	SecuritySetup security_setup;
-	//TODO randomize the group name
-	std::wstring group_name = L"Shark_cage_test_group";
+	//randomize the group name
+	UUID uuid;
+	if (::UuidCreate(&uuid) != RPC_S_OK)
+	{
+		std::cout << "Failed to create UUID" << std::endl;
+		return 1;
+	}
+
+	RPC_WSTR uuid_str;
+	if (::UuidToString(&uuid, &uuid_str) != RPC_S_OK)
+	{
+		std::cout << "Failed to convert UUID to rpc string" << std::endl;
+		return 1;
+	}
+
+	std::wstring uuid_stl(reinterpret_cast<wchar_t*>(uuid_str));
+	if (uuid_stl.empty())
+	{
+		::RpcStringFree(&uuid_str);
+		std::cout << "Failed to convert UUID rpc string to stl string" << std::endl;
+		return 1;
+	}
+
+	::RpcStringFree(&uuid_str);
+
+	std::wstring group_name = std::wstring(L"shark_cage_group_").append(uuid_stl);
 	auto security_attributes = security_setup.GetSecurityAttributes(group_name);
 
 	if (!security_attributes.has_value())

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -20,12 +20,13 @@
 #pragma comment(lib, "Rpcrt4.lib")
 
 NetworkManager network_manager(ContextType::MANAGER);
-std::optional<std::wstring> generateUuid();;
+std::optional<std::wstring> generateUuid();
 
 int main()
 {
+	getchar();
 	CageManager cage_manager;
-
+	
 	SecuritySetup security_setup;
 	//randomize the group name
 	auto uuid_stl_opt = generateUuid();

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -20,6 +20,7 @@
 #pragma comment(lib, "Rpcrt4.lib")
 
 NetworkManager network_manager(ContextType::MANAGER);
+std::optional<std::wstring> generateUuid();;
 
 int main()
 {
@@ -27,29 +28,11 @@ int main()
 
 	SecuritySetup security_setup;
 	//randomize the group name
-	UUID uuid;
-	if (::UuidCreate(&uuid) != RPC_S_OK)
-	{
-		std::cout << "Failed to create UUID" << std::endl;
+	auto uuid_stl_opt = generateUuid();
+	if (!uuid_stl_opt.has_value()) {
 		return 1;
 	}
-
-	RPC_WSTR uuid_str;
-	if (::UuidToString(&uuid, &uuid_str) != RPC_S_OK)
-	{
-		std::cout << "Failed to convert UUID to rpc string" << std::endl;
-		return 1;
-	}
-
-	std::wstring uuid_stl(reinterpret_cast<wchar_t*>(uuid_str));
-	if (uuid_stl.empty())
-	{
-		::RpcStringFree(&uuid_str);
-		std::cout << "Failed to convert UUID rpc string to stl string" << std::endl;
-		return 1;
-	}
-
-	::RpcStringFree(&uuid_str);
+	auto uuid_stl = uuid_stl_opt.value();;
 
 	std::wstring group_name = std::wstring(L"shark_cage_group_").append(uuid_stl);
 	auto security_attributes = security_setup.GetSecurityAttributes(group_name);
@@ -68,7 +51,6 @@ int main()
 
 	if (parse_result != CageMessage::START_PROCESS)
 	{
-		//tokenLib::deleteLocalGroup(static_cast<LPWSTR const>(const_cast<wchar_t*>((group_name.c_str()))));
 		tokenLib::deleteLocalGroup(const_cast<wchar_t*>((group_name.c_str())));
 		std::cout << "Could not process incoming message" << std::endl;
 		return 1;
@@ -118,33 +100,14 @@ int main()
 	return 0;
 }
 
-void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data, const std::wstring group_name)
+void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data, const std::wstring &group_name)
 {
 	// name should be unique every time -> create UUID
-	UUID uuid;
-	if (::UuidCreate(&uuid) != RPC_S_OK)
-	{
-		std::cout << "Failed to create UUID" << std::endl;
+	auto uuid_stl_opt = generateUuid();
+	if (!uuid_stl_opt.has_value()) {
 		return;
 	}
-
-	RPC_WSTR uuid_str;
-	if (::UuidToString(&uuid, &uuid_str) != RPC_S_OK)
-	{
-		std::cout << "Failed to convert UUID to rpc string" << std::endl;
-		return;
-	}
-
-	std::wstring uuid_stl(reinterpret_cast<wchar_t*>(uuid_str));
-	if (uuid_stl.empty())
-	{
-		::RpcStringFree(&uuid_str);
-		std::cout << "Failed to convert UUID rpc string to stl string" << std::endl;
-		return;
-	}
-
-	::RpcStringFree(&uuid_str);
-
+	auto uuid_stl = uuid_stl_opt.value();
 	HANDLE tokenHandle = nullptr;
 	//TODO: close this handle
 	if (!tokenLib::constructUserTokenWithGroup(const_cast<wchar_t*>((group_name.c_str())), tokenHandle)) {
@@ -514,4 +477,31 @@ void CageManager::ActivateApp(
 			handles.push_back(process_info.hProcess);
 		}
 	}
+}
+
+std::optional<std::wstring> generateUuid() {
+	UUID uuid;
+	if (::UuidCreate(&uuid) != RPC_S_OK)
+	{
+		std::cout << "Failed to create UUID" << std::endl;
+		return std::nullopt;
+	}
+
+	RPC_WSTR uuid_str;
+	if (::UuidToString(&uuid, &uuid_str) != RPC_S_OK)
+	{
+		std::cout << "Failed to convert UUID to rpc string" << std::endl;
+		return std::nullopt;
+	}
+
+	std::wstring uuid_stl(reinterpret_cast<wchar_t*>(uuid_str));
+	if (uuid_stl.empty())
+	{
+		::RpcStringFree(&uuid_str);
+		std::cout << "Failed to convert UUID rpc string to stl string" << std::endl;
+		return std::nullopt;
+	}
+
+	::RpcStringFree(&uuid_str);
+	return uuid_stl;
 }

--- a/SharkCage/CageManager/CageManager.cpp
+++ b/SharkCage/CageManager/CageManager.cpp
@@ -144,13 +144,11 @@ void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageD
 
 	::RpcStringFree(&uuid_str);
 
-	HANDLE tokenHandle = 0;
+	HANDLE tokenHandle = nullptr;
 	//TODO: close this handle
 	if (!tokenLib::constructUserTokenWithGroup(static_cast<LPWSTR>(const_cast<wchar_t*>((group_name.c_str()))), tokenHandle)) {
 		std::cout << "Cannot create required token" << std::endl;
-		getchar();
 		return;
-
 	}
 
 	const std::wstring DESKTOP_NAME = std::wstring(L"shark_cage_desktop_").append(uuid_stl);

--- a/SharkCage/CageManager/CageManager.h
+++ b/SharkCage/CageManager/CageManager.h
@@ -3,7 +3,7 @@
 class CageManager
 {
 public:
-	void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data,const std::wstring group_name);
+	void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data, const std::wstring &group_name);
 	bool CageManager::ProcessRunning(const std::wstring &process_path);
 
 private:
@@ -20,6 +20,7 @@ private:
 		SECURITY_ATTRIBUTES security_attributes,
 		STARTUPINFO info,
 		std::vector<HANDLE> &handles);
+
 
 	// FIXME: extra class for this? process handling? -> could also do the wait stuff
 	static BOOL CALLBACK GetOpenWindowHandles(_In_ HWND hwnd, _In_ LPARAM l_param);

--- a/SharkCage/CageManager/CageManager.h
+++ b/SharkCage/CageManager/CageManager.h
@@ -22,7 +22,6 @@ private:
 		STARTUPINFO info,
 		std::vector<HANDLE> &handles);
 
-
 	// FIXME: extra class for this? process handling? -> could also do the wait stuff
 	static BOOL CALLBACK GetOpenWindowHandles(_In_ HWND hwnd, _In_ LPARAM l_param);
 	static BOOL CALLBACK GetOpenProcesses(_In_ HWND hwnd, _In_ LPARAM l_param);

--- a/SharkCage/CageManager/CageManager.h
+++ b/SharkCage/CageManager/CageManager.h
@@ -13,6 +13,7 @@ private:
 		const int work_area_width,
 		const std::wstring &labeler_window_class_name);
 	void CageManager::ActivateApp(
+		const HANDLE tokenHandle,
 		const std::wstring &path,
 		const HANDLE &event,
 		const HDESK &desktop_handle,

--- a/SharkCage/CageManager/CageManager.h
+++ b/SharkCage/CageManager/CageManager.h
@@ -13,7 +13,7 @@ private:
 		const int work_area_width,
 		const std::wstring &labeler_window_class_name);
 	void CageManager::ActivateApp(
-		const HANDLE tokenHandle,
+		const HANDLE token_handle,
 		const std::wstring &path,
 		const HANDLE &event,
 		const HDESK &desktop_handle,

--- a/SharkCage/CageManager/CageManager.h
+++ b/SharkCage/CageManager/CageManager.h
@@ -3,7 +3,7 @@
 class CageManager
 {
 public:
-	void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data);
+	void CageManager::StartCage(SECURITY_ATTRIBUTES security_attributes, const CageData &cage_data,const std::wstring group_name);
 	bool CageManager::ProcessRunning(const std::wstring &process_path);
 
 private:

--- a/SharkCage/CageManager/SecuritySetup.cpp
+++ b/SharkCage/CageManager/SecuritySetup.cpp
@@ -8,7 +8,7 @@
 
 #pragma comment(lib, "netapi32.lib")
 
-std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes(std::wstring group_name)
+std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes(const std::wstring &group_name)
 {
 	auto group_sid = CreateSID(group_name);
 	auto access_control_list = CreateACL(std::move(group_sid));
@@ -58,7 +58,7 @@ std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes(std::wst
 	return security_attributes;
 }
 
-std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> SecuritySetup::CreateSID(std::wstring group_name)
+std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> SecuritySetup::CreateSID(const std::wstring &group_name)
 {
 	LOCALGROUP_INFO_0 localgroup_info;
 	DWORD buffer_size = 0;

--- a/SharkCage/CageManager/SecuritySetup.cpp
+++ b/SharkCage/CageManager/SecuritySetup.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 
 #include "SecuritySetup.h"
-#include <string>
 #include <vector>
 #include <iostream>
 #include <LM.h>
@@ -9,9 +8,9 @@
 
 #pragma comment(lib, "netapi32.lib")
 
-std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes()
+std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes(std::wstring group_name)
 {
-	auto group_sid = CreateSID();
+	auto group_sid = CreateSID(group_name);
 	auto access_control_list = CreateACL(std::move(group_sid));
 
 	if (!access_control_list.has_value())
@@ -59,9 +58,8 @@ std::optional<SECURITY_ATTRIBUTES> SecuritySetup::GetSecurityAttributes()
 	return security_attributes;
 }
 
-std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> SecuritySetup::CreateSID()
+std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> SecuritySetup::CreateSID(std::wstring group_name)
 {
-	std::wstring group_name = L"shark_cage_group";
 	LOCALGROUP_INFO_0 localgroup_info;
 	DWORD buffer_size = 0;
 

--- a/SharkCage/CageManager/SecuritySetup.h
+++ b/SharkCage/CageManager/SecuritySetup.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 
 template<typename T>
 auto local_free_deleter = [&](T resource) { ::LocalFree(resource); };
@@ -17,10 +18,10 @@ public:
 		}
 	}
 
-	std::optional<SECURITY_ATTRIBUTES> GetSecurityAttributes();
+	std::optional<SECURITY_ATTRIBUTES> GetSecurityAttributes(std::wstring group_name);
 
 private:
-	std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> CreateSID();
+	std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> CreateSID(std::wstring group_name);
 	std::optional<PACL> CreateACL(std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> group_sid);
 
 	PSECURITY_DESCRIPTOR security_descriptor;

--- a/SharkCage/CageManager/SecuritySetup.h
+++ b/SharkCage/CageManager/SecuritySetup.h
@@ -18,10 +18,10 @@ public:
 		}
 	}
 
-	std::optional<SECURITY_ATTRIBUTES> GetSecurityAttributes(std::wstring group_name);
+	std::optional<SECURITY_ATTRIBUTES> GetSecurityAttributes(const std::wstring &group_name);
 
 private:
-	std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> CreateSID(std::wstring group_name);
+	std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> CreateSID(const std::wstring &group_name);
 	std::optional<PACL> CreateACL(std::unique_ptr<PSID, decltype(local_free_deleter<PSID>)> group_sid);
 
 	PSECURITY_DESCRIPTOR security_descriptor;

--- a/SharkCage/CageService/CageService.cpp
+++ b/SharkCage/CageService/CageService.cpp
@@ -35,7 +35,8 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 		return std::nullopt;
 	}
 
-	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriate_token)) {
+	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriate_token)) 
+	{
 		std::wostringstream os;
 		os << "The token aquisition was unsuccessfull!";
 		::OutputDebugString(os.str().c_str());

--- a/SharkCage/CageService/CageService.cpp
+++ b/SharkCage/CageService/CageService.cpp
@@ -35,8 +35,7 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 		return std::nullopt;
 	}
 
-	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriate_token))
-	{
+	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriate_token)) {
 		std::wostringstream os;
 		os << "The token aquisition was unsuccessfull!";
 		::OutputDebugString(os.str().c_str());

--- a/SharkCage/CageService/CageService.cpp
+++ b/SharkCage/CageService/CageService.cpp
@@ -35,7 +35,7 @@ std::optional<HANDLE> CageService::CreateImpersonatingUserToken()
 		return std::nullopt;
 	}
 
-	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriate_token)) 
+	if (!tokenLib::aquireTokenWithPrivilegesForTokenManipulation(appropriate_token))
 	{
 		std::wostringstream os;
 		os << "The token aquisition was unsuccessfull!";

--- a/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
@@ -13,8 +13,9 @@
 #pragma comment(lib, "netapi32.lib")
 #pragma comment(lib, "Wtsapi32.lib")
 
-ULONG getCurrentSessionID();
+std::optional<HANDLE> getCurrentUserToken();
 bool changeTokenCreationPrivilege(bool privilegeStatus);
+bool changeTcbPrivilege(bool privilegeStatus);
 bool getGroupSid(LPWSTR groupName, PSID &sid);
 bool hasSeCreateTokenPrivilege(const HANDLE processHandle);
 bool hasSeTcbPrivilege(const HANDLE processHandle);
@@ -120,14 +121,14 @@ namespace tokenLib {
 	}
 
 	DLLEXPORT bool constructUserTokenWithGroup(PSID sid, HANDLE &token) {
-		HANDLE userToken = nullptr;
 
 		//get handle to token of current process
-		HANDLE currentProcessHandle = GetCurrentProcess();
-		if (!OpenProcessToken(currentProcessHandle, TOKEN_DUPLICATE | TOKEN_ALL_ACCESS, &userToken)) {
-			wprintf(L"  Cannot aquire template token\n");
+		auto userTokenHandleOpt = getCurrentUserToken();
+		if (!userTokenHandleOpt.has_value()) {
+			std::wcout << L"Cannot aquire template token" << std::endl;
 			return false;
 		}
+		HANDLE userToken = userTokenHandleOpt.value();
 
 		//sample the token into individual structures
 		std::unique_ptr<tokenTemplate> tokenDeconstructed{};
@@ -355,6 +356,23 @@ ULONG getCurrentSessionID() {
 	return 0;
 }
 
+std::optional<HANDLE> getCurrentUserToken() {
+	HANDLE userToken = 0;
+	ULONG sessionId = ::WTSGetActiveConsoleSessionId();
+	if (!changeTcbPrivilege(true)) {
+		std::wcout << L"Cannot aquire SE_TCB_NAME privilege needed" << std::endl;
+		return std::nullopt;
+	}
+	if (!WTSQueryUserToken(sessionId, &userToken)) {
+		std::wcout << L"Cannot query user token";
+		changeTcbPrivilege(false);
+		return std::nullopt;
+	}
+	changeTcbPrivilege(false);
+	return userToken;
+
+}
+
 bool getGroupSid(LPWSTR groupName, PSID &sid) {
 	SID_NAME_USE accountType;
 	DWORD bufferSize = 0, buffer2Size = 0;
@@ -419,9 +437,8 @@ bool setPrivilege(
 	return TRUE;
 }
 
-bool changeTokenCreationPrivilege(bool privilegeStatus) {
+bool changePrivilege(bool privilegeStatus, LPCTSTR privilege) {
 	//keeping this for future debug purposes
-	//will be important if ever implementing token capture for a token having SE_CREATE_TOKEN_NAME included
 	/*
 	DWORD bufferSize = 0;
 	GetUserName(NULL, &bufferSize);
@@ -429,6 +446,7 @@ bool changeTokenCreationPrivilege(bool privilegeStatus) {
 	GetUserName(pUserName, &bufferSize);
 	wprintf(L"User account accessed: %s\n", pUserName);
 	delete[](BYTE*) pUserName;
+	getchar();
 	*/
 
 	HANDLE currentProcessHandle;
@@ -438,8 +456,16 @@ bool changeTokenCreationPrivilege(bool privilegeStatus) {
 		wprintf(L"Error getting token for privilege escalation\n");
 		return false;
 	}
-	return setPrivilege(userTokenHandle, SE_CREATE_TOKEN_NAME, privilegeStatus);
+	return setPrivilege(userTokenHandle, privilege, privilegeStatus);
 	CloseHandle(userTokenHandle);
+}
+
+bool changeTokenCreationPrivilege(bool privilegeStatus) {
+	return changePrivilege(privilegeStatus, SE_CREATE_TOKEN_NAME);
+}
+
+bool changeTcbPrivilege(bool privilegeStatus){
+	return changePrivilege(privilegeStatus, SE_TCB_NAME);
 }
 
 tokenTemplate::tokenTemplate(HANDLE &userToken) {

--- a/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenLib.cpp
@@ -369,8 +369,13 @@ std::optional<HANDLE> getCurrentUserToken() {
 		return std::nullopt;
 	}
 	changeTcbPrivilege(false);
-	return userToken;
-
+	HANDLE duplicatedUserToken = nullptr;
+	if (!DuplicateTokenEx(userToken, TOKEN_ALL_ACCESS, NULL, SecurityImpersonation, TokenPrimary, &duplicatedUserToken)) {
+		std::wcout << L"Cannot duplicate token" << std::endl;
+		return std::nullopt;
+	}
+	CloseHandle(userToken);
+	return duplicatedUserToken;
 }
 
 bool getGroupSid(LPWSTR groupName, PSID &sid) {
@@ -438,17 +443,6 @@ bool setPrivilege(
 }
 
 bool changePrivilege(bool privilegeStatus, LPCTSTR privilege) {
-	//keeping this for future debug purposes
-	/*
-	DWORD bufferSize = 0;
-	GetUserName(NULL, &bufferSize);
-	LPTSTR pUserName = (LPTSTR) new BYTE[bufferSize * sizeof(TCHAR)];
-	GetUserName(pUserName, &bufferSize);
-	wprintf(L"User account accessed: %s\n", pUserName);
-	delete[](BYTE*) pUserName;
-	getchar();
-	*/
-
 	HANDLE currentProcessHandle;
 	HANDLE userTokenHandle;
 	currentProcessHandle = GetCurrentProcess();

--- a/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
+++ b/SharkCage/SharedFunctionality/tokenLib/tokenManipulation.h
@@ -10,11 +10,9 @@
 namespace tokenLib {
 	/**
 	* Function gets a SID of a group and creates a token with a group entry added in the token
-	* Source of the token is the token of the process itself. Returned token is identical to the calling process token, just includes one more group
-	* SE_CREATE_TOKEN_NAME must be held and enabled by a calling process, to successfully call this method
-	* Mind that there are security implications to the current implementations - such that f.x.:
-	* every process launched with token created by this function has SE_CREATE_TOKEN_NAME privilege, granting it basically any access to the system
-	* This can be mitigated by calling CreateRestrictedToken() function on the output of this method
+	* Source of the token is token of the user attached to active physical console session. 
+	* Returned token is identical to the calling process token, just includes one more group
+	* Process must run in LocalSystem context and SE_CREATE_TOKEN_NAME and SE_TCB_NAME privileges must be held, to successfully call this method
 	* @param sid pointer to sid to be added to the token (IN)
 	* @param token reference to handle to requested token (OUT)
 	* @return true if success
@@ -24,11 +22,9 @@ namespace tokenLib {
 	/**
 	* Function gets a name of a group and creates a token with a group entry added in the token. The group must exist, otherwise the function will fail
 	* The group will not be deleted at return, otherwise the token would be useless.
-	* Source of the token is the token of the process itself. Returned token is identical to the calling process token, just includes one more group
-	* SE_CREATE_TOKEN_NAME must be held and enabled by a calling process, to successfully call this method
-	* Mind that there are security implications to the current implementations - such that f.x.:
-	* every process launched with token created by this function has SE_CREATE_TOKEN_NAME privilege, granting it basically any access to the system
-	* This can be mitigated by calling CreateRestrictedToken() function on the output of this method
+	* Source of the token is token of the user attached to active physical console session.
+	* Returned token is identical to the calling process token, just includes one more group
+	* Process must run in LocalSystem context and SE_CREATE_TOKEN_NAME and SE_TCB_NAME privileges must be held, to successfully call this method
 	* @param groupName string literal representing the name of nonexistent group to be added to the token (IN)
 	* @param token reference to handle to requested token (OUT)
 	* @return true if success


### PR DESCRIPTION
Finally, (with all the issues fixed) an up to date and functional version of starting caged apps in a context  of logged on user

**Note**: due  to starting as the same user as uses of a normal console session, some applications won´t launch if they already have an active instance on a default desktop (so far only encountered for Google Chrome). I suspect that they are not capable of running on two desktops simultaneously, when using identical user profile. This issue did not came up before, because caged applications were started as `NT AUTHORITY` thus loading a different user profile when in cage.